### PR TITLE
Simplify PHP lint action

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -61,13 +61,7 @@ jobs:
         # outputs.phpcs so it will re-run if standards or dependencies change.
         if: ${{ steps.paths.outputs.php == 'true' }}
         run: |
-          CHANGED_FILES=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}..${{ github.head_ref }} | grep .php$)
-          echo "Changed files:"
-          echo "$CHANGED_FILES"
-          if [[ -n "$CHANGED_FILES" ]]; then
-            echo "Running phpcs..."
-            phpcs --report-full --report-checkstyle=./phpcs-report.xml $CHANGED_FILES
-          fi
+          phpcs --report-full --report-checkstyle=./phpcs-report.xml $CHANGED_FILES
 
       - name: Report PHPCS results
         if: ${{ always() && steps.phpcs.outcome == 'failure' }}


### PR DESCRIPTION
This is a new codebase, so there's no reason to restrict linting to only changed files - ideally we want the whole codebase to be linted.