### PR TITLE
Fix CSP header for websocket connection

### DIFF
--- a/inc/assets.php
+++ b/inc/assets.php
@@ -19,6 +19,24 @@ function bootstrap() {
 
 	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_editor_assets' );
 	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_frontend_assets' );
+	add_filter( 'wp_headers', __NAMESPACE__ . '\\set_connect_src_origins', 901, 2 );
+}
+
+/**
+ * Expand the 'connect-src' origins list to allow ws: websocket.
+ *
+ * Resolves bug in wiki security plugin that only permits wss.
+ *
+ * @param string[] $headers Associative array of headerd to set.
+ * @return string[] Updated HTTP headers array.
+ */
+function set_connect_src_origins( array $headers ) : array {
+	$headers['Content-Security-Policy'] = preg_replace(
+		"/connect-src 'self'/",
+		"connect-src 'self' ws://localhost:8080",
+		$headers['Content-Security-Policy']
+	);
+	return $headers;
 }
 
 /**


### PR DESCRIPTION
This resolves an issue where WebPack uses `ws:` protocol but the Wikimedia Security Plugin only permits `wss`. This should be relaxed in the security plugin, but for now this PR will fix websocket terminal errors like this:

<img width="785" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/e88b2902-8aac-4306-be92-e58a843bbaba">

