### PR TITLE
945: Fix build-to-release-branch workflow to match wp-scripts repo structure

### DIFF
--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           source_branch: develop
           release_branch: release-develop
-          built_asset_paths: ./*.css package-lock.json assets/dist
+          built_asset_paths: ./*.css src
           build_script: |
             npm ci
             npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           source_branch: main
           release_branch: release
-          built_asset_paths: ./*.css package-lock.json assets/dist
+          built_asset_paths: ./*.css src
           build_script: |
             npm ci
             npm run build


### PR DESCRIPTION
Assets directory no longer exists following #8

There is also no practical reason to ship our package lockfile, it is not used outside of the build process