### PR TITLE
963: Add controls for setting a group block ToC name and full-height override

### DIFF
--- a/inc/blocks/core-group.php
+++ b/inc/blocks/core-group.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Block-specific PHP logic for the Expandable block.
+ */
+declare( strict_types=1 );
+
+namespace WMF\Reports\Blocks\Core_Group;
+
+/**
+ * Attach hooks.
+ */
+function bootstrap() : void {
+	add_filter( 'render_block', __NAMESPACE__ . '\\inject_ids', 10, 2 );
+}
+
+/**
+ * Render the stored ID of the ToC title as an ID attribute on the group block.
+ *
+ * @param string $block_content The block content.
+ * @param array  $block         The full block, including name and attributes.
+ * @return string Filtered block content.
+ */
+function inject_ids( string $block_content, array $block ) : string {
+	if ( $block['blockName'] !== 'core/group' ) {
+		return $block_content;
+	}
+
+	if ( empty( $block['attrs']['tocSlug'] ) ) {
+		return $block_content;
+	}
+
+	// Render stored slug as an ID attribute on the container.
+	// TODO: Worth exploring https://developer.wordpress.org/reference/classes/wp_html_tag_processor/ ?
+	return preg_replace(
+		'/class="wp-block-group/',
+		sprintf( 'id="%s" class="wp-block-group', $block['attrs']['tocSlug'] ),
+		$block_content
+	);
+}

--- a/plugin.php
+++ b/plugin.php
@@ -17,8 +17,10 @@ require_once __DIR__ . '/inc/assets.php';
 require_once __DIR__ . '/inc/asset-loader/namespace.php';
 require_once __DIR__ . '/inc/asset-loader/utilities.php';
 require_once __DIR__ . '/inc/blocks/expandable.php';
+require_once __DIR__ . '/inc/blocks/core-group.php';
 require_once __DIR__ . '/inc/report.php';
 
 Assets\bootstrap();
+Blocks\Core_Group\bootstrap();
 Blocks\Expandable\bootstrap();
 Report\bootstrap();

--- a/src/blocks/core/group.js
+++ b/src/blocks/core/group.js
@@ -29,7 +29,7 @@ const withCustomGroupControls = createHigherOrderComponent( ( BlockEdit ) => {
 			return <BlockEdit key="edit" { ...props } />;
 		}
 		const { attributes, setAttributes } = props;
-		console.log( { attributes } ); // eslint-disable-line
+
 		return (
 			<>
 				<BlockEdit key="edit" { ...props } />
@@ -92,6 +92,37 @@ addFilter(
 );
 
 /**
+ * Allow the "fill viewport height" toggle to be previewed. The style override
+ * is rendered in PHP with a filter, so we filter in the editor too.
+ */
+const withFillViewportHeightStyle = createHigherOrderComponent(
+	( BlockListBlock ) => {
+		return ( props ) => {
+			if (
+				props.name !== 'core/group' ||
+				! props.attributes.fullViewportHeight
+			) {
+				return <BlockListBlock { ...props } />;
+			}
+			const mergedCssClasses = `${
+				props.className || ''
+			} wp-block-group-is-full-viewport-height`;
+			return (
+				<BlockListBlock { ...props } className={ mergedCssClasses } />
+			);
+		};
+	},
+	'withFillViewportHeightStyle'
+);
+
+addFilter(
+	'editor.BlockListBlock',
+	'wmf-reports/block-list-block/group-block',
+	withFillViewportHeightStyle,
+	100
+);
+
+/**
  * Add additional custom properties to group blocks.
  *
  * @todo Should this be restricted to groups on Report post type objects?
@@ -139,6 +170,10 @@ if ( module.hot ) {
 		removeFilter(
 			'editor.BlockEdit',
 			'wmf-reports/add-group-block-controls'
+		);
+		removeFilter(
+			'editor.BlockListBlock',
+			'wmf-reports/block-list-block/group-block'
 		);
 		removeFilter(
 			'blocks.registerBlockType',

--- a/src/blocks/core/group.js
+++ b/src/blocks/core/group.js
@@ -8,6 +8,15 @@ import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
+const toIdString = ( string ) => {
+	return string
+		.toLowerCase()
+		.replace( /[^a-z0-9]/g, ' ' )
+		.trim()
+		.split( /\s+/ )
+		.join( '-' );
+};
+
 /**
  * Filter the BlockEdit component to inject custom controls into core/group block.
  *
@@ -20,6 +29,7 @@ const withCustomGroupControls = createHigherOrderComponent( ( BlockEdit ) => {
 			return <BlockEdit key="edit" { ...props } />;
 		}
 		const { attributes, setAttributes } = props;
+		console.log( { attributes } ); // eslint-disable-line
 		return (
 			<>
 				<BlockEdit key="edit" { ...props } />
@@ -44,9 +54,13 @@ const withCustomGroupControls = createHigherOrderComponent( ( BlockEdit ) => {
 									'Table of Contents Label',
 									'wmf-reports'
 								) }
-								value={ attributes.tableOfContentsLabel }
-								onChange={ ( tableOfContentsLabel ) => {
-									setAttributes( { tableOfContentsLabel } );
+								value={ attributes.tocLabel }
+								onChange={ ( tocLabel ) => {
+									const id = toIdString( tocLabel );
+									setAttributes( {
+										tocSlug: `toc-${ id }`,
+										tocLabel,
+									} );
 								} }
 							/>
 						) }
@@ -55,10 +69,10 @@ const withCustomGroupControls = createHigherOrderComponent( ( BlockEdit ) => {
 								'Fill viewport height',
 								'wmf-reports'
 							) }
-							value={ attributes.fullViewportHeight }
-							onChange={ ( fullViewportHeight ) =>
-								setAttributes( { fullViewportHeight } )
-							}
+							checked={ attributes.fullViewportHeight }
+							onChange={ ( fullViewportHeight ) => {
+								setAttributes( { fullViewportHeight } );
+							} }
 							help={ __(
 								'Makes this group take up at minimum a full viewport of vertical space',
 								'wmf-reports'
@@ -99,7 +113,10 @@ function customizeGroupBlockAttributes( settings, name ) {
 				type: 'boolean',
 				default: false,
 			},
-			tableOfContentsLabel: {
+			tocLabel: {
+				type: 'string',
+			},
+			tocSlug: {
 				type: 'string',
 			},
 			fullViewportHeight: {

--- a/src/blocks/core/group.js
+++ b/src/blocks/core/group.js
@@ -94,7 +94,8 @@ addFilter(
 
 /**
  * Allow the "fill viewport height" toggle to be previewed. The style override
- * is rendered in PHP with a filter, so we filter in the editor too.
+ * is added on the frontend using a PHP filter, but we use JS to filter in-editor
+ * to add the override classname.
  */
 const withFillViewportHeightStyle = createHigherOrderComponent(
 	( BlockListBlock ) => {

--- a/src/blocks/core/group.js
+++ b/src/blocks/core/group.js
@@ -1,0 +1,131 @@
+/**
+ * Customizations for the core group block.
+ */
+
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { addFilter, removeFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Filter the BlockEdit component to inject custom controls into core/group block.
+ *
+ * @param {React.ReactNode} BlockEdit Gutenberg's default edit component for a block.
+ * @return {React.ReactNode} Filtered edit component.
+ */
+const withCustomGroupControls = createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		if ( ! props.isSelected || props.name !== 'core/group' ) {
+			return <BlockEdit key="edit" { ...props } />;
+		}
+		const { attributes, setAttributes } = props;
+		return (
+			<>
+				<BlockEdit key="edit" { ...props } />
+				<InspectorControls>
+					<PanelBody
+						title={ __( 'Report group settings', 'wmf-reports' ) }
+						initialOpen={ true }
+					>
+						<ToggleControl
+							label={ __(
+								'Include in Table of Contents',
+								'wmf-reports'
+							) }
+							checked={ attributes.includeInToC }
+							onChange={ ( includeInToC ) => {
+								setAttributes( { includeInToC } );
+							} }
+						/>
+						{ attributes.includeInToC && (
+							<TextControl
+								label={ __(
+									'Table of Contents Label',
+									'wmf-reports'
+								) }
+								value={ attributes.tableOfContentsLabel }
+								onChange={ ( tableOfContentsLabel ) => {
+									setAttributes( { tableOfContentsLabel } );
+								} }
+							/>
+						) }
+						<ToggleControl
+							label={ __(
+								'Fill viewport height',
+								'wmf-reports'
+							) }
+							value={ attributes.fullViewportHeight }
+							onChange={ ( fullViewportHeight ) =>
+								setAttributes( { fullViewportHeight } )
+							}
+							help={ __(
+								'Makes this group take up at minimum a full viewport of vertical space',
+								'wmf-reports'
+							) }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			</>
+		);
+	};
+}, 'withCustomGroupControls' );
+
+addFilter(
+	'editor.BlockEdit',
+	'wmf-reports/add-group-block-controls',
+	withCustomGroupControls
+);
+
+/**
+ * Add additional custom properties to group blocks.
+ *
+ * @todo Should this be restricted to groups on Report post type objects?
+ *
+ * @param {Object} settings Block settings object.
+ * @param {string} name     Block type name.
+ * @return {Object} Filtered settings object.
+ */
+function customizeGroupBlockAttributes( settings, name ) {
+	if ( name !== 'core/group' ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		attributes: {
+			...settings.attributes,
+			includeInToC: {
+				type: 'boolean',
+				default: false,
+			},
+			tableOfContentsLabel: {
+				type: 'string',
+			},
+			fullViewportHeight: {
+				type: 'boolean',
+				default: false,
+			},
+		},
+	};
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'wmf-reports/custom-attributes/group-block',
+	customizeGroupBlockAttributes
+);
+
+if ( module.hot ) {
+	module.hot.accept();
+	module.hot.dispose( () => {
+		removeFilter(
+			'editor.BlockEdit',
+			'wmf-reports/add-group-block-controls'
+		);
+		removeFilter(
+			'blocks.registerBlockType',
+			'wmf-reports/custom-attributes/group-block'
+		);
+	} );
+}

--- a/src/blocks/core/group.js
+++ b/src/blocks/core/group.js
@@ -2,6 +2,7 @@
  * Customizations for the core group block.
  */
 
+import { createBlock } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
@@ -154,6 +155,24 @@ function customizeGroupBlockAttributes( settings, name ) {
 				type: 'boolean',
 				default: false,
 			},
+		},
+		transforms: {
+			...settings.transforms,
+			from: [
+				// Permit transforming from expandable back to a group block.
+				{
+					type: 'block',
+					blocks: [ 'wmf-reports/expandable' ],
+					transform: ( attributes, innerBlocks ) => {
+						return createBlock(
+							'core/group',
+							attributes,
+							innerBlocks
+						);
+					},
+				},
+				...settings.transforms.from,
+			],
 		},
 	};
 }

--- a/src/blocks/expandable/index.js
+++ b/src/blocks/expandable/index.js
@@ -1,4 +1,4 @@
-import { registerBlockType } from '@wordpress/blocks';
+import { createBlock, registerBlockType } from '@wordpress/blocks';
 
 import Edit from './edit';
 import Save from './save';
@@ -11,6 +11,24 @@ registerBlockType( metadata.name, {
 	...metadata,
 	edit: Edit,
 	save: Save,
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/group' ],
+				transform: ( attributes, innerBlocks ) => {
+					return createBlock(
+						metadata.name,
+						attributes,
+						innerBlocks
+					);
+				},
+			},
+		],
+		// Attempted to put a "to" transform here to convert from Expandable TO
+		// a group block, but did not take effect. Filtered core/group instead.
+		// See blocks/core/group.js.
+	},
 } );
 
 // Block HMR boilerplate.

--- a/src/editor.js
+++ b/src/editor.js
@@ -3,6 +3,10 @@
  */
 import { registerBlockCollection } from '@wordpress/blocks';
 
+// Import block customization modules which aren't build as standalone bundles.
+import './blocks/core/group.js';
+
+// Editor-wide styles
 import './editor.scss';
 
 // Bundle all the Annual Report blocks into a single collection.

--- a/src/editor.scss
+++ b/src/editor.scss
@@ -6,3 +6,7 @@
 		min-width: 4rem;
 	}
 }
+
+.wp-block-group-is-full-viewport-height {
+	height: 100vh;
+}

--- a/src/frontend.scss
+++ b/src/frontend.scss
@@ -4,3 +4,8 @@ button:focus {
 	box-shadow: 0 0 0 2px rgba(0, 125, 250, 0.8);
 	border-radius: 2px;
 }
+
+/* Styles used for core block modifications */
+.wp-block-group-is-full-viewport-height {
+	height: 100vh;
+}


### PR DESCRIPTION
Adds a new controls section to the group block as described in [WIKI-963](https://github.com/humanmade/wikimedia/issues/963)

<img width="280" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/9116c68d-abd3-4cc5-b04d-d8802ad6d892">

Until we implement the ToC block, only the viewport height toggle will impact the editor. However, both items have an effect on the rendered markup.

- The ToC title will be slugified and set as an ID on the group, so that a ToC block may later link to it
- The group block will be set to `100vh` height and take up the full viewport width when that attribute is set
- In editor, the viewport height toggle should cause that element to expand in height. Test on both frontend and editor to understand how the preview plays out.

--------------

**Note**: This PR bundles a change to the Expandable block to enable it to be transformed from/to a Group block. This was added as a part of this PR for simplicity, since it depends on the same Group block filters (using a `to` transform on the Expandable itself was unsuccessful)

![Uploading expandable-transfrom.gif…]()
