### PR TITLE
Display Prettier issues as an ESLint "warning," not "error"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,8 @@
 	"extends": [ "plugin:@wordpress/eslint-plugin/recommended" ],
 	"rules": {
 		"jsdoc/no-undefined-types": [ "off" ],
+		"jsdoc/check-line-alignment": [ "warn" ],
+		"jsdoc/check-tag-names": [ "warn" ],
 		"prettier/prettier": [ "warn" ]
 	}
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
 	"extends": [ "plugin:@wordpress/eslint-plugin/recommended" ],
 	"rules": {
-		"jsdoc/no-undefined-types": [ "off" ]
+		"jsdoc/no-undefined-types": [ "off" ],
+		"prettier/prettier": [ "warn" ]
 	}
 }


### PR DESCRIPTION
Fundamentally, code style does not represent a logic error. Prettier should not be tracked as an ESLint error because that makes it hard in-editor to distinguish between actual issues and stylistic things that will be solved by "npm run format".