### PR TITLE
945: Pin GH Action dependencies and fix file inclusion issue in release action

### DIFF
--- a/.github/actions/build-to-release-branch/action.yml
+++ b/.github/actions/build-to-release-branch/action.yml
@@ -26,7 +26,7 @@ runs:
         git config user.email "<>"
 
     - name: Check out release branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
       with:
         ref: ${{ inputs.release_branch }}
         fetch-depth: 0

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -11,7 +11,7 @@ runs:
 
   steps:
     - name: Set up Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -22,7 +22,7 @@ runs:
 
     - name: Cache dependencies
       id: cache-node-dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: node-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}-${{ inputs.cache_version }}

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Set up PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d # v2.30.0
       with:
         php-version: ${{ matrix.php-version }}
         coverage: none
@@ -29,7 +29,7 @@ runs:
 
     - name: Cache dependencies
       id: cache-php-dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: php-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('composer.lock') }}-${{ inputs.cache_version }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
 
       - name: Paths filters
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: paths
         with:
           filters: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,14 +9,14 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ '8.0' ]
+        php-version: [ '8.1' ]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
 
       - name: Paths filters
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: paths
         with:
           filters: |

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -15,18 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Merge and build
         uses: ./.github/actions/build-to-release-branch
         with:
           source_branch: develop
           release_branch: release-develop
-          built_asset_paths: ./*.css src
+          built_asset_paths: build
           build_script: |
             npm ci
             npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,18 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Merge and build
         uses: ./.github/actions/build-to-release-branch
         with:
           source_branch: main
           release_branch: release
-          built_asset_paths: ./*.css src
+          built_asset_paths: build
           build_script: |
             npm ci
             npm run build


### PR DESCRIPTION
While testing prior PRs in develop, I noticed that we only were deploying the CSS files in our build folder. This was a result of having a leftover line of theme-specific configuration in our `release` actions, which was not targeting the entire build folder as intended.

This PR corrects that issue, and also pins a number of other GH Action dependencies per the standards introduced while developing [WIKI-900](https://github.com/humanmade/wikimedia/issues/900)