### PR TITLE
Introduce block style variations for repeated report elements

### DIFF
--- a/inc/assets.php
+++ b/inc/assets.php
@@ -80,7 +80,8 @@ function enqueue_editor_assets() : void {
 		build_file_uri( 'editor.css' ),
 		[
 			'dashicons'
-		]
+		],
+		filemtime( build_file_path( 'editor.css' ) )
 	);
 }
 
@@ -99,6 +100,7 @@ function enqueue_frontend_assets() : void {
 		build_file_uri( 'frontend.css' ),
 		[
 			'dashicons'
-		]
+		],
+		filemtime( build_file_path( 'frontend.css' ) )
 	);
 }

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -13,7 +13,8 @@ use WMF\Reports\Asset_Loader;
  */
 function bootstrap() {
 	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_editor_assets' );
-	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_frontend_assets' );
+	add_action( 'enqueue_block_assets', __NAMESPACE__ . '\\enqueue_frontend_styles' );
+	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_frontend_scripts' );
 	add_filter( 'wp_headers', __NAMESPACE__ . '\\set_connect_src_origins', 901, 2 );
 }
 
@@ -88,13 +89,18 @@ function enqueue_editor_assets() : void {
 /**
  * Enqueue these assets only on the frontend.
  */
-function enqueue_frontend_assets() : void {
+function enqueue_frontend_scripts() : void {
 	Asset_Loader\enqueue_script_asset(
 		'annual-report-plugin-frontend',
 		build_file_path( 'frontend.asset.php' ),
 		build_file_uri( 'frontend.js' )
 	);
+}
 
+/**
+ * Enqueue these assets in the editor and the frontend.
+ */
+function enqueue_frontend_styles() : void {
 	wp_enqueue_style(
 		'annual-report-plugin-frontend',
 		build_file_uri( 'frontend.css' ),

--- a/inc/editor/styles.php
+++ b/inc/editor/styles.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Block styles for content editors to quickly vary the appearance of existing blocks.
+ */
+
+namespace WMF\Reports\Editor\Styles;
+
+/**
+ * Hook into WordPress
+ */
+function bootstrap() {
+	add_action( 'after_setup_theme', __NAMESPACE__ . '\\register_styles' );
+}
+
+/**
+ * Register our styles.
+ */
+function register_styles() : void {
+	register_block_style(
+		'core/heading',
+		[
+			'name' => 'report-section-heading',
+			'label' => __( 'Report Section Heading', 'wmf-reports' ),
+		]
+	);
+}

--- a/plugin.php
+++ b/plugin.php
@@ -20,10 +20,11 @@ require_once __DIR__ . '/inc/blocks/expandable.php';
 require_once __DIR__ . '/inc/blocks/core-group.php';
 require_once __DIR__ . '/inc/report.php';
 require_once __DIR__ . '/inc/editor/patterns.php';
-require_once __DIR__ . '/inc/editor/patterns/hero.php';
+require_once __DIR__ . '/inc/editor/styles.php';
 
 Assets\bootstrap();
 Blocks\Core_Group\bootstrap();
 Blocks\Expandable\bootstrap();
 Report\bootstrap();
 Editor\Patterns\bootstrap();
+Editor\Styles\bootstrap();

--- a/src/editor.js
+++ b/src/editor.js
@@ -8,6 +8,7 @@ import './blocks/core/group.js';
 
 // Editor-wide styles
 import './editor.scss';
+import './frontend-global.scss';
 
 // Bundle all the Annual Report blocks into a single collection.
 registerBlockCollection( 'wikimedia-annual-report', {

--- a/src/editor.scss
+++ b/src/editor.scss
@@ -1,6 +1,6 @@
 @font-face {
-	font-family: 'Noto Sans';
-	src: url('../assets/fonts/NotoSans-VariableFont_wdth-wght.ttf');
+	font-family: "Noto Sans";
+	src: url("../assets/fonts/NotoSans-VariableFont_wdth-wght.ttf");
 }
 
 .wmf-expandable-dimensions-panel {

--- a/src/frontend-global.scss
+++ b/src/frontend-global.scss
@@ -1,5 +1,5 @@
 /* Helpers */
-@import 'helpers/variables';
+@import "helpers/variables";
 
 /* Non-block-specific styles */
 button:focus {
@@ -8,8 +8,8 @@ button:focus {
 }
 
 @font-face {
-	font-family: 'Noto Sans';
-	src: url('../assets/fonts/NotoSans-VariableFont_wdth-wght.ttf');
+	font-family: "Noto Sans";
+	src: url("../assets/fonts/NotoSans-VariableFont_wdth-wght.ttf");
 }
 
 /* Patterns */

--- a/src/frontend-global.scss
+++ b/src/frontend-global.scss
@@ -29,3 +29,8 @@ button:focus {
 .wp-block-group-is-full-viewport-height {
 	height: 100vh;
 }
+
+/* Editor style overrides */
+.editor-styles-wrapper div.wp-block-group.has-background:not(:only-child) {
+	margin-bottom: 0;
+}

--- a/src/frontend-global.scss
+++ b/src/frontend-global.scss
@@ -20,6 +20,9 @@ button:focus {
 		max-width: none;
 		padding: 0;
 	}
+	.wp-block-group.has-background:not(:only-child) {
+		margin-bottom: 0;
+	}
 }
 
 /* Styles used for core block modifications */

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -8,3 +8,6 @@ import './frontend-global.scss';
 // reloading does not seem to work as expected.
 import './blocks/expandable/frontend.scss';
 import './blocks/table-of-contents/frontend.scss';
+
+// Import block styles.
+import './styles/core-heading-report-section-heading.scss';

--- a/src/styles/core-heading-report-section-heading.scss
+++ b/src/styles/core-heading-report-section-heading.scss
@@ -1,0 +1,11 @@
+.is-style-report-section-heading {
+	background: #000;
+	color: #fff;
+	font-family: 'Noto Sans';
+	text-transform: uppercase;
+	font-size: 0.9375rem;
+	font-weight: bold;
+	padding: 0.5em;
+	margin: 0;
+	width: max-content;
+}

--- a/src/styles/core-heading-report-section-heading.scss
+++ b/src/styles/core-heading-report-section-heading.scss
@@ -2,10 +2,16 @@
 	background: #000;
 	color: #fff;
 	font-family: 'Noto Sans';
-	text-transform: uppercase;
 	font-size: 0.9375rem;
 	font-weight: bold;
-	padding: 0.5em;
-	margin: 0;
+	margin: 0 0 -0.5em 0;
+	padding: 0.5rem 1rem;
+	text-transform: uppercase;
 	width: max-content;
+
+	// Slightly break out of group container.
+	.wp-block-group.has-background &:first-child {
+		transform: translate( 0, -50% );
+		margin-top: -1.25rem;
+	}
 }

--- a/src/styles/core-heading-report-section-heading.scss
+++ b/src/styles/core-heading-report-section-heading.scss
@@ -13,6 +13,11 @@
 	// Slightly break out of group container.
 	.wp-block-group.has-background &:first-child {
 		transform: translate(0, -50%);
-		margin-top: -1.25rem;
+		z-index: 2;
+
+		.single-wmf-report & {
+			// Only apply this rule outside the editor.
+			margin-top: -1.25rem;
+		}
 	}
 }

--- a/src/styles/core-heading-report-section-heading.scss
+++ b/src/styles/core-heading-report-section-heading.scss
@@ -1,9 +1,9 @@
 .is-style-report-section-heading {
 	background: #000;
 	color: #fff;
-	font-family: 'Noto Sans';
+	font-family: "Noto Sans", sans-serif;
 	font-size: 0.9375rem;
-	font-weight: bold;
+	font-weight: 700;
 	margin: 0 0 -0.5em 0;
 	padding: 0.5rem 1rem;
 	text-transform: uppercase;
@@ -11,7 +11,7 @@
 
 	// Slightly break out of group container.
 	.wp-block-group.has-background &:first-child {
-		transform: translate( 0, -50% );
+		transform: translate(0, -50%);
 		margin-top: -1.25rem;
 	}
 }

--- a/src/styles/core-heading-report-section-heading.scss
+++ b/src/styles/core-heading-report-section-heading.scss
@@ -1,3 +1,4 @@
+.editor-styles-wrapper .wp-block.is-style-report-section-heading,
 .is-style-report-section-heading {
 	background: #000;
 	color: #fff;


### PR DESCRIPTION
This PR converts @philipjohn 's heading treatment into a block style, and sets up the scaffolding to handle styles efficiently. Makes a few asset loading changes to ensure our frontend styles can be previewed in-editor.

There are still some editor styling inconsistencies (see gap between colored group backgrounds) but I feel resolving these is out-of-scope for this project, and should be handled in Shiro.

Editor view:
<img width="808" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/34bab51d-b468-4f41-a961-59452f81b362">

Frontend view:
<img width="709" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/9a59f0c4-7a09-47a8-94aa-341db5643fad">
