### PR TITLE
Introduce a Reports\is_report_page() helper

### DIFF
--- a/inc/editor.php
+++ b/inc/editor.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * General editor functionality.
+ */
+
+namespace WMF\Reports\Editor;
+
+/**
+ * Determine whether the current screen is a block editor admin screen.
+ *
+ * @return boolean Are we on a block editor admin screen?
+ */
+function is_block_editor_admin_screen() : bool {
+	if ( ! is_admin() || ! function_exists( 'get_current_screen' ) ) {
+		return false;
+	}
+
+	$screen = get_current_screen();
+
+	return isset( $screen ) && $screen->is_block_editor();
+}
+
+/**
+ * Determine whether we are on a post edit screen in the admin.
+ *
+ * Internal helper function for use detecting block editor before we can access
+ * get_current_screen, as well as to aid in disabling QueryMonitor when it might
+ * cause performance impacts due to excessive DOM weight.
+ *
+ * @param string $post_type Optionally also check whether the current edit post screen
+ *                          is for a specific custom post type object.
+ * @return bool Are we on a post edit screen in the admin?
+ */
+function is_edit_post_screen( string $post_type = '' ) : bool {
+	if ( ! is_admin() ) {
+		return false;
+	}
+
+	// Short-circuit if get_current_screen IS available.
+	if ( is_block_editor_admin_screen() ) {
+		if ( ! empty( $post_type ) ) {
+			return ( get_current_screen()->post_type ?? '' ) === $post_type;
+		}
+		return true;
+	}
+
+	// Fall back to manual inspection of current page.
+	$pagenow = $GLOBALS['pagenow'];
+
+	if ( ! in_array( $pagenow, [ 'post.php', 'post-new.php' ], true ) ) {
+		return false;
+	}
+
+	if ( $pagenow === 'post.php' && strpos( $_SERVER['REQUEST_URI'], 'action=edit' ) === false ) {
+		return false;
+	}
+
+	if ( ! empty( $post_type ) ) {
+		if ( $pagenow === 'post-new.php' ) {
+			return sanitize_text_field( $_GET['post_type'] ) === $post_type;
+		}
+		$post_id = sanitize_text_field( $_GET['post'] );
+		if ( ! is_numeric( $post_id ) ) {
+			return false;
+		}
+		return get_post_type( $post_id ) === $post_type;
+	}
+	return true;
+}

--- a/inc/report.php
+++ b/inc/report.php
@@ -6,6 +6,8 @@ declare( strict_types=1 );
 
 namespace WMF\Reports\Report;
 
+use WMF\Reports\Editor;
+
 const POST_TYPE = 'wmf-report';
 
 /**
@@ -98,4 +100,23 @@ function single_template( string $template ) : string {
 	}
 
 	return $template;
+}
+
+/**
+ * Check whether the current admin or frontend page is a WMF Report item or the
+ * editor for a WMF Report item.
+ *
+ * @return bool Whether we're viewing or editing a Report.
+ */
+function is_report_page() : bool {
+	if ( ! is_admin() ) {
+		$current_post_type = get_post_type();
+		if ( ! empty( $current_post_type ) ) {
+			return $current_post_type === POST_TYPE;
+		}
+		// Not sure how to handle returning before post global is set.
+		// Tried to use wpcom_vip_url_to_postid, but it seemed to return the wrong ID.
+		return false;
+	}
+	return Editor\is_edit_post_screen( POST_TYPE );
 }

--- a/plugin.php
+++ b/plugin.php
@@ -19,6 +19,7 @@ require_once __DIR__ . '/inc/asset-loader/utilities.php';
 require_once __DIR__ . '/inc/blocks/expandable.php';
 require_once __DIR__ . '/inc/blocks/core-group.php';
 require_once __DIR__ . '/inc/report.php';
+require_once __DIR__ . '/inc/editor.php';
 require_once __DIR__ . '/inc/editor/colors.php';
 require_once __DIR__ . '/inc/editor/patterns.php';
 require_once __DIR__ . '/inc/editor/styles.php';


### PR DESCRIPTION
This might be a basis for some of what @goldenapples was suggesting around further restricting where and when we enqueue or allow Report-based scripts, styles, PHP filters, and theme features. There's an unfinished piece where it won't work as early as `init()`, but should still be useful on many hooks.