### PR TITLE
Fixes for the development site

### DIFF
--- a/inc/assets.php
+++ b/inc/assets.php
@@ -40,6 +40,7 @@ function set_connect_src_origins( array $headers ) : array {
 		},
 		''
 	);
+
 	$headers['Content-Security-Policy'] = preg_replace(
 		"/connect-src 'self'/",
 		"connect-src 'self' $localhost_srcs",
@@ -48,7 +49,7 @@ function set_connect_src_origins( array $headers ) : array {
 
 	$headers['Content-Security-Policy'] = preg_replace(
 		"/script-src 'self'/",
-		"script-src 'self' blob: https://wikimedia.vipdev.lndo.site",
+		"script-src 'self' blob: https://wikimedia.vipdev.lndo.site https://wikimediafoundation-org-develop.go-vip.co",
 		$headers['Content-Security-Policy']
 	);
 

--- a/inc/editor/patterns/financial-statements.php
+++ b/inc/editor/patterns/financial-statements.php
@@ -24,8 +24,8 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"33.33%"} -->
-<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:image {"id":74197,"sizeSlug":"large","linkDestination":"none"} -->
+<!-- wp:column {"width":"33.33%", "className":"wmf-pattern-financial-statements__score"} -->
+<div class="wp-block-column wmf-pattern-financial-statements__score" style="flex-basis:33.33%"><!-- wp:image {"id":74197,"sizeSlug":"large","linkDestination":"none"} -->
 <figure class="wp-block-image size-large"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png?w=980" alt="" class="wp-image-74197"/><figcaption class="wp-element-caption">Lorem ipsum dolor sit amet at cras ac massa erat hac mattis dolore.</figcaption></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>

--- a/inc/editor/patterns/report.php
+++ b/inc/editor/patterns/report.php
@@ -387,8 +387,8 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"33.33%"} -->
-<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:image {"id":74197,"sizeSlug":"large","linkDestination":"none"} -->
+<!-- wp:column {"width":"33.33%", "className":"wmf-pattern-financial-statements__score"} -->
+<div class="wp-block-column wmf-pattern-financial-statements__score" style="flex-basis:33.33%"><!-- wp:image {"id":74197,"sizeSlug":"large","linkDestination":"none"} -->
 <figure class="wp-block-image size-large"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png?w=980" alt="" class="wp-image-74197"/><figcaption class="wp-element-caption">Lorem ipsum dolor sit amet at cras ac massa erat hac mattis dolore.</figcaption></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>

--- a/src/blocks/expandable/frontend.scss
+++ b/src/blocks/expandable/frontend.scss
@@ -23,6 +23,7 @@
 .expandable-expander {
 	background-color: #fff;
 	border: 1px solid;
+	cursor: pointer;
 	display: inline-block;
 	font-weight: 700;
 	padding: 0.5rem 3rem 0.5rem 3rem;

--- a/src/patterns/financial-statements.scss
+++ b/src/patterns/financial-statements.scss
@@ -1,0 +1,7 @@
+.wmf-pattern-financial-statements {
+	&__score {
+		.wp-block-image {
+			margin-bottom: 0.5rem;
+		}
+	}
+}

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -50,6 +50,10 @@
 		margin-top: 0;
 	}
 
+	mark {
+		background: transparent;
+	}
+
 	.wp-block-group.alignfull,
 	.alignfull {
 		margin-left: 0;


### PR DESCRIPTION
Fixes a couple of issues occurring on the dev site in order to fix maps and styles.

- Security exceptions are needed for blob:https://wikimediafoundation-org-develop.go-vip.co/ so that the map works correctly
- Use of mark for selecting inline font colours has a yellow background, needs to be made transparent
- Adds a cursor on hover for expandable buttons
- Fixes image spacing in one of the patterns