### PR TITLE
Template Integration: Integrate with Shiro to suppress page title

### DIFF
--- a/inc/theme-integration.php
+++ b/inc/theme-integration.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Integration logic for Foundation & Endowment sites.
+ */
+declare( strict_types=1 );
+
+namespace WMF\Reports\Theme_Integration;
+
+use WMF\Reports\Report;
+
+/**
+ * Attach hooks.
+ */
+function bootstrap() {
+	add_action( 'wmf_hide_page_title', __NAMESPACE__ . '\\suppress_page_title_h1_on_reports' );
+}
+
+/**
+ * Do not show the page title H1 on reports, we use an H1 within page content.
+ *
+ * @param bool $hide_page_title Whether to hide page title
+ */
+function suppress_page_title_h1_on_reports( bool $hide_page_title ) : bool {
+	if ( is_singular( Report\POST_TYPE ) ) {
+		return true;
+	}
+	return $hide_page_title;
+}

--- a/plugin.php
+++ b/plugin.php
@@ -38,6 +38,7 @@ require_once __DIR__ . '/inc/editor/patterns/previous-reports.php';
 require_once __DIR__ . '/inc/editor/patterns/report.php';
 require_once __DIR__ . '/inc/editor/patterns/wrapped.php';
 require_once __DIR__ . '/inc/editor/styles.php';
+require_once __DIR__ . '/inc/theme-integration.php';
 
 Assets\bootstrap();
 Blocks\Core_Group\bootstrap();
@@ -47,3 +48,4 @@ Report\bootstrap();
 Editor\Colors\bootstrap();
 Editor\Patterns\bootstrap();
 Editor\Styles\bootstrap();
+Theme_Integration\bootstrap();

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -6,20 +6,23 @@
 		padding: 0;
 	}
 
-	// We stack our nav on top of Shiro's, in that theme.
-	[data-dropdown-status="initialized"] .primary-nav {
-		min-height: 0;
-		height: 3rem;
+	@media (min-width: 1024px) {
+		// We stack our nav on top of Shiro's, in that theme.
+		[data-dropdown-status="initialized"] .primary-nav {
+			min-height: 0;
+			height: 3rem;
+			margin-top: 4rem;
 
-		&:focus-within {
-			z-index: 10;
+			&:focus-within {
+				z-index: 10;
+			}
 		}
-	}
 
-	[data-dropdown-status="initialized"] .primary-nav__items {
-		max-width: $width-breakpoint-wide;
-		margin: 0 auto;
-		padding: 0;
+		[data-dropdown-status="initialized"] .primary-nav__items {
+			max-width: $width-breakpoint-wide;
+			margin: 0 auto;
+			padding: 0;
+		}
 	}
 
 	.header-main .header-content {

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -6,6 +6,26 @@
 		padding: 0;
 	}
 
+	// We stack our nav on top of Shiro's, in that theme.
+	[data-dropdown-status="initialized"] .primary-nav {
+		min-height: 0;
+		height: 3rem;
+
+		&:focus-within {
+			z-index: 10;
+		}
+	}
+
+	[data-dropdown-status="initialized"] .primary-nav__items {
+		max-width: $width-breakpoint-wide;
+		margin: 0 auto;
+		padding: 0;
+	}
+
+	.header-main .header-content {
+		margin: 0;
+	}
+
 	h2:not([class*="is-style-"]) {
 
 		&.wp-block-heading {

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -12,16 +12,23 @@
 			min-height: 0;
 			height: 3rem;
 			margin-top: 4rem;
-
-			&:focus-within {
-				z-index: 10;
-			}
 		}
 
 		[data-dropdown-status="initialized"] .primary-nav__items {
 			max-width: $width-breakpoint-wide;
 			margin: 0 auto;
 			padding: 0;
+		}
+
+		// Focus management to enable keyboard selection of page-level nav
+		// items even when they are occluded by the Report navigation.
+		.header-default {
+			position: relative;
+
+			.header-inner .primary-nav:focus-within {
+				background: #fff;
+				z-index: 3000; // overrides 2000 of .site-header
+			}
 		}
 	}
 


### PR DESCRIPTION
Pairs with https://github.com/wikimedia/shiro-wordpress-theme/pull/143 to enable this plugin to suppress the page title from being output on report pages.

Also adjusts the styling of the fixed desktop nav, to better enable us to layer our own report-specific nav over it.

> [!NOTE]
> This does **not** remove or hide the desktop nav. It is still present in the report mobile designs, and removing it entirely prevents keyboard users from navigating back to other parts of the site; this did not feel intentional. Instead, we will layer our own "jump list" navigation elements over this one.

<img width="1175" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/6258cc8e-528d-46d4-bc6d-344456673d38">