### PR TITLE
#988 - Previous Reports Carousel

### DIFF
--- a/inc/editor/patterns/endowment.php
+++ b/inc/editor/patterns/endowment.php
@@ -21,8 +21,30 @@ const PATTERN = <<<CONTENT
 <p>Lorem ipsum dolor sit amet congue eu eiusmod tempus eiusmod malesuada mi tristique. Nisl tempor senectus dictum consequat posuere mattis labore. Vel porta aliqua volutpat posuere at nulla at. Molestie nibh dolore mollis elit quisque lacus rhoncus. Ornare venenatis tincidunt id tempor scelerisque quis porta magna.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading {"level":3,"className":"is-style-h1"} -->
-<h3 class="wp-block-heading is-style-h1">Accordion goes here</h3>
-<!-- /wp:heading --></div>
+<!-- wp:shiro/accordion {"className":"wp-block-wmf-reports-accordion\u002d\u002dalt"} -->
+<div class="accordion-wrapper wp-block-shiro-accordion wp-block-wmf-reports-accordion--alt undefined"><!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst</h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item -->
+
+<!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst<mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color"></mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item -->
+
+<!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst<mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color"></mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item -->
+
+<!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst<mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color"></mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item --></div>
+<!-- /wp:shiro/accordion --></div>
 <!-- /wp:group -->
 CONTENT;

--- a/inc/editor/patterns/financial-statements.php
+++ b/inc/editor/patterns/financial-statements.php
@@ -20,14 +20,22 @@ const PATTERN = <<<CONTENT
 <!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
 <div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:paragraph -->
-<p>Lorem ipsum dolor sit amet iaculis purus viverra velit hendrerit vestibulum pulvinar mauris.</p>
+<p>Lorem ipsum dolor sit amet iaculis purus viverra velit hendrerit vestibulum pulvinar mauris. Lorem ipsum dolor sit amet iaculis purus viverra velit hendrerit vestibulum pulvinar mauris.</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"33.33%", "className":"wmf-pattern-financial-statements__score"} -->
-<div class="wp-block-column wmf-pattern-financial-statements__score" style="flex-basis:33.33%"><!-- wp:image {"id":74197,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png?w=980" alt="" class="wp-image-74197"/><figcaption class="wp-element-caption">Lorem ipsum dolor sit amet at cras ac massa erat hac mattis dolore.</figcaption></figure>
-<!-- /wp:image --></div>
+<!-- wp:column {"width":"33.33%","className":"wmf-pattern-financial-statements__score"} -->
+<div class="wp-block-column wmf-pattern-financial-statements__score" style="flex-basis:33.33%"><!-- wp:image {"align":"center","id":74791,"width":"103px","height":"auto","sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/03/Guidestar-Platinum-Transparence-2021.png?w=103" alt="" class="wp-image-74791" style="width:103px;height:auto"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"center","id":74790,"width":"109px","height":"auto","sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/03/Four-Stars.png?w=87" alt="" class="wp-image-74790" style="width:109px;height:auto"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><strong>98/100</strong></p>
+<!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
@@ -37,9 +45,31 @@ const PATTERN = <<<CONTENT
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:heading {"level":3,"className":"is-style-h1"} -->
-<h3 class="wp-block-heading is-style-h1">Accordion goes here</h3>
-<!-- /wp:heading --></div>
+<div class="wp-block-column"><!-- wp:shiro/accordion {"className":"wp-block-wmf-reports-accordion\u002d\u002dalt"} -->
+<div class="accordion-wrapper wp-block-shiro-accordion wp-block-wmf-reports-accordion--alt undefined"><!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst<mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color">00%</mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item -->
+
+<!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst <mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color">00%</mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item -->
+
+<!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst <mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color">00%</mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item -->
+
+<!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst <mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color">00%</mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item --></div>
+<!-- /wp:shiro/accordion --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 

--- a/inc/editor/patterns/financial-statements.php
+++ b/inc/editor/patterns/financial-statements.php
@@ -24,8 +24,8 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"33.33%"} -->
-<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:image {"id":74197,"sizeSlug":"large","linkDestination":"none"} -->
+<!-- wp:column {"width":"33.33%", "className":"wmf-pattern-financial-statements__score"} -->
+<div class="wp-block-column wmf-pattern-financial-statements__score" style="flex-basis:33.33%"><!-- wp:image {"id":74197,"sizeSlug":"large","linkDestination":"none"} -->
 <figure class="wp-block-image size-large"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png?w=980" alt="" class="wp-image-74197"/><figcaption class="wp-element-caption">Lorem ipsum dolor sit amet at cras ac massa erat hac mattis dolore.</figcaption></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>

--- a/inc/editor/patterns/previous-reports.php
+++ b/inc/editor/patterns/previous-reports.php
@@ -15,13 +15,224 @@ const PATTERN = <<<CONTENT
 <!-- /wp:heading -->
 
 <!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">Archive</h3>
+<h3 class="wp-block-heading">Previous Reports</h3>
 <!-- /wp:heading -->
 
-<!-- wp:paragraph -->
-<p>TODO Carousel</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Archive</h3>
+<!-- /wp:heading --></div>
+<!-- /wp:group -->
+
+<!-- wp:wmf-reports/report-archive -->
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"id":74154,"width":"240px","height":"300px","scale":"cover","sizeSlug":"large","linkDestination":"none","className":"wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-large is-resized wp-block-wmf-reports-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2023/12/Ingushetia_Russia_Armkhi_Ingush_tower.jpg?w=1024" alt="" class="wp-image-74154" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>FIRST The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>Lorem ipsum dolor sit amet mattis ut magna faucibus vulputate nullam feugiat arcu nulla aliquet.</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74079,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2023/12/Rabock_i_narbild.jpg" alt="" class="wp-image-74079" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>LAST The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+<!-- /wp:wmf-reports/report-archive --></div>
 <!-- /wp:group -->
 CONTENT;

--- a/inc/editor/patterns/report.php
+++ b/inc/editor/patterns/report.php
@@ -387,8 +387,8 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"33.33%"} -->
-<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:image {"id":74197,"sizeSlug":"large","linkDestination":"none"} -->
+<!-- wp:column {"width":"33.33%", "className":"wmf-pattern-financial-statements__score"} -->
+<div class="wp-block-column wmf-pattern-financial-statements__score" style="flex-basis:33.33%"><!-- wp:image {"id":74197,"sizeSlug":"large","linkDestination":"none"} -->
 <figure class="wp-block-image size-large"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png?w=980" alt="" class="wp-image-74197"/><figcaption class="wp-element-caption">Lorem ipsum dolor sit amet at cras ac massa erat hac mattis dolore.</figcaption></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>

--- a/inc/editor/patterns/report.php
+++ b/inc/editor/patterns/report.php
@@ -383,14 +383,22 @@ const PATTERN = <<<CONTENT
 <!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
 <div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:paragraph -->
-<p>Lorem ipsum dolor sit amet iaculis purus viverra velit hendrerit vestibulum pulvinar mauris.</p>
+<p>Lorem ipsum dolor sit amet iaculis purus viverra velit hendrerit vestibulum pulvinar mauris. Lorem ipsum dolor sit amet iaculis purus viverra velit hendrerit vestibulum pulvinar mauris.</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"33.33%", "className":"wmf-pattern-financial-statements__score"} -->
-<div class="wp-block-column wmf-pattern-financial-statements__score" style="flex-basis:33.33%"><!-- wp:image {"id":74197,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png?w=980" alt="" class="wp-image-74197"/><figcaption class="wp-element-caption">Lorem ipsum dolor sit amet at cras ac massa erat hac mattis dolore.</figcaption></figure>
-<!-- /wp:image --></div>
+<!-- wp:column {"width":"33.33%","className":"wmf-pattern-financial-statements__score"} -->
+<div class="wp-block-column wmf-pattern-financial-statements__score" style="flex-basis:33.33%"><!-- wp:image {"align":"center","id":74791,"width":"103px","height":"auto","sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/03/Guidestar-Platinum-Transparence-2021.png?w=103" alt="" class="wp-image-74791" style="width:103px;height:auto"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"center","id":74790,"width":"109px","height":"auto","sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/03/Four-Stars.png?w=87" alt="" class="wp-image-74790" style="width:109px;height:auto"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><strong>98/100</strong></p>
+<!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
@@ -400,9 +408,31 @@ const PATTERN = <<<CONTENT
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:heading {"level":3,"className":"is-style-h1"} -->
-<h3 class="wp-block-heading is-style-h1">Accordion goes here</h3>
-<!-- /wp:heading --></div>
+<div class="wp-block-column"><!-- wp:shiro/accordion {"className":"wp-block-wmf-reports-accordion\u002d\u002dalt"} -->
+<div class="accordion-wrapper wp-block-shiro-accordion wp-block-wmf-reports-accordion--alt undefined"><!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst<mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color">00%</mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item -->
+
+<!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst <mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color">00%</mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item -->
+
+<!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst <mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color">00%</mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item -->
+
+<!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst <mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color">00%</mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item --></div>
+<!-- /wp:shiro/accordion --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
@@ -526,9 +556,31 @@ const PATTERN = <<<CONTENT
 <p>Lorem ipsum dolor sit amet congue eu eiusmod tempus eiusmod malesuada mi tristique. Nisl tempor senectus dictum consequat posuere mattis labore. Vel porta aliqua volutpat posuere at nulla at. Molestie nibh dolore mollis elit quisque lacus rhoncus. Ornare venenatis tincidunt id tempor scelerisque quis porta magna.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading {"level":3,"className":"is-style-h1"} -->
-<h3 class="wp-block-heading is-style-h1">Accordion goes here</h3>
-<!-- /wp:heading --></div>
+<!-- wp:shiro/accordion {"className":"wp-block-wmf-reports-accordion\u002d\u002dalt"} -->
+<div class="accordion-wrapper wp-block-shiro-accordion wp-block-wmf-reports-accordion--alt undefined"><!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst</h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item -->
+
+<!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst<mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color"></mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item -->
+
+<!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst<mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color"></mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item -->
+
+<!-- wp:shiro/accordion-item -->
+<div class="accordion-item"><button class="accordion-item__title"><h3 class="accordion-item__title-text">Lorem ipsum dolor sit amet diam aliquam fusce dictumst<mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-base-10-color"></mark></h3></button><div class="accordion-item__content"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet aliquam tempus posuere turpis in fusce consequat. Rhoncus duis aliquet at turpis velit orci adipiscing mollis do fermentum. Blandit eros pretium morbi urna malesuada molestie sed pharetra gravida mattis. Ac malesuada odio urna sodales porttitor fusce cras mollis aliquet feugiat aliquam. Ullamcorper volutpat euismod cursus consectetur erat sagittis dapibus aenean turpis nisl habitasse.</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:shiro/accordion-item --></div>
+<!-- /wp:shiro/accordion --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"wide","backgroundColor":"base80","className":"wp-block-wmf-reports-donate","metadata":{"name":"Donate"}} -->

--- a/inc/editor/patterns/report.php
+++ b/inc/editor/patterns/report.php
@@ -816,13 +816,225 @@ const PATTERN = <<<CONTENT
 <!-- /wp:heading -->
 
 <!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">Archive</h3>
+<h3 class="wp-block-heading">Previous Reports</h3>
 <!-- /wp:heading -->
 
-<!-- wp:paragraph -->
-<p>TODO Carousel</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Archive</h3>
+<!-- /wp:heading --></div>
+<!-- /wp:group -->
+
+<!-- wp:wmf-reports/report-archive -->
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"id":74154,"width":"240px","height":"300px","scale":"cover","sizeSlug":"large","linkDestination":"none","className":"wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-large is-resized wp-block-wmf-reports-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2023/12/Ingushetia_Russia_Armkhi_Ingush_tower.jpg?w=1024" alt="" class="wp-image-74154" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>FIRST The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>Lorem ipsum dolor sit amet mattis ut magna faucibus vulputate nullam feugiat arcu nulla aliquet.</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74197,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+
+<!-- wp:wmf-reports/report -->
+<!-- wp:image {"lightbox":{"className":"is-style-default wp-block-wmf-reports-report__image","enabled":false,"id":74197,"linkDestination":"none","scale":"cover","sizeSlug":"full","url":"/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png"},"id":74079,"width":"240px","height":"300px","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"is-style-default wp-block-wmf-reports-report__image"} -->
+<figure class="wp-block-image size-full is-resized is-style-default wp-block-wmf-reports-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2023/12/Rabock_i_narbild.jpg" alt="" class="wp-image-74079" style="object-fit:cover;width:240px;height:300px"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base10"}}}},"textColor":"base10","className":"wp-block-wmf-reports-report__date"} -->
+<p class="wp-block-wmf-reports-report__date has-base-10-color has-text-color has-link-color"><strong>2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"\u0022wp-block-wmf-reports-report__title is-style-default"} -->
+<h3 class="wp-block-heading &quot;wp-block-wmf-reports-report__title is-style-default"><a href="#"><strong>LAST The people behind a year of impact around the world</strong></a></h3>
+<!-- /wp:heading -->
+<!-- /wp:wmf-reports/report -->
+<!-- /wp:wmf-reports/report-archive --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 CONTENT;

--- a/src/blocks/expandable/frontend.scss
+++ b/src/blocks/expandable/frontend.scss
@@ -23,6 +23,7 @@
 .expandable-expander {
 	background-color: #fff;
 	border: 1px solid;
+	cursor: pointer;
 	display: inline-block;
 	font-weight: 700;
 	padding: 0.5rem 3rem 0.5rem 3rem;

--- a/src/blocks/map/view.js
+++ b/src/blocks/map/view.js
@@ -121,12 +121,15 @@ const setMarker = ( id ) => {
 				setTimeout( () => {
 					nextMarkerInfoBox.style.opacity = 1;
 
-					markerInfoBox.style.opacity = 0;
 					markerInfoBox.style.height =
 						nextMarkerInfoBox.offsetHeight + 'px';
 
 					processingAnimation = true;
 				}, 2 );
+
+				setTimeout( () => {
+					markerInfoBox.style.opacity = 0;
+				}, 250 );
 
 				setTimeout( () => {
 					nextMarkerInfoBox.style.height = null;

--- a/src/blocks/report-archive/block.json
+++ b/src/blocks/report-archive/block.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wmf-reports/report-archive",
+	"version": "0.1.0",
+	"title": "Report Archive",
+	"category": "widgets",
+	"icon": "image-flip-horizontal",
+	"description": "",
+	"attributes": {
+		"align": {
+			"type": "string",
+			"default": "full"
+		}
+	},
+	"example": {},
+	"supports": {
+		"html": false,
+		"align": [ "full" ]
+	},
+	"textdomain": "wmf-reports",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"render": "file:./render.php",
+	"viewScript": "file:./view.js"
+}

--- a/src/blocks/report-archive/edit.js
+++ b/src/blocks/report-archive/edit.js
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 

--- a/src/blocks/report-archive/edit.js
+++ b/src/blocks/report-archive/edit.js
@@ -1,0 +1,102 @@
+import { __ } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+// eslint-disable-next-line import/no-unresolved
+import './editor.scss';
+
+import InnerBlocksDisplaySingle from '../../components/inner-block-slider/inner-block-single-display';
+import Navigation from '../../components/inner-block-slider/navigation';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @param {Object} props          Block Props.
+ * @param {number} props.clientId Client ID.
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {Element} Element to render.
+ */
+export default function Edit( { clientId } ) {
+	// Get the innerBlocks (slideBlocks).
+	const slideBlocks = useSelect(
+		( select ) =>
+			select( 'core/block-editor' ).getBlock( clientId ).innerBlocks
+	);
+
+	const { insertBlock } = useDispatch( 'core/block-editor' );
+
+	// Track state in a ref, to allow us to determine if slides are added or removed.
+	const slideCount = useRef( slideBlocks.length );
+
+	// Keep track of the selected Slide.
+	const [ currentItemIndex, setCurrentItemIndex ] = useState( 0 );
+
+	/**
+	 * Add Slide Function.
+	 */
+	const addSlide = () => {
+		const id = Date.now();
+		const created = createBlock( 'wmf-reports/report', {
+			id,
+		} );
+		insertBlock( created, undefined, clientId );
+	};
+
+	/**
+	 * If a slide is added, switch to the new slide. If one is deleted, make sure we don't
+	 * show a non-existent slide.
+	 */
+	useEffect( () => {
+		if ( slideBlocks.length > slideCount.current ) {
+			// Slide added
+			setCurrentItemIndex( slideBlocks.length - 1 );
+		} else if ( slideBlocks.length < slideCount.current ) {
+			// Slide deleted
+			if ( currentItemIndex + 1 > slideBlocks.length ) {
+				setCurrentItemIndex( slideBlocks.length - 1 );
+			}
+		}
+
+		// Update ref with new value..
+		slideCount.current = slideBlocks.length;
+	}, [ slideBlocks.length, currentItemIndex, slideCount, slideBlocks ] );
+
+	const blockProps = useBlockProps( {
+		className: 'report-archive carousel',
+	} );
+
+	return (
+		<div { ...blockProps }>
+			<div className="inner-block-slider">
+				<InnerBlocksDisplaySingle
+					allowedBlocks={ [ 'wmf-reports/report' ] }
+					className="slides"
+					currentItemIndex={ currentItemIndex }
+					parentBlockId={ clientId }
+					template={ [ 'wmf-reports/report' ] }
+				/>
+				<p className="help">
+					{ __(
+						'Click on the + below to add a slide.',
+						'wmf-reports'
+					) }
+				</p>
+				<Navigation
+					addSlide={ addSlide }
+					addSlideEnabled={ true }
+					currentPage={ currentItemIndex + 1 }
+					nextEnabled={ currentItemIndex + 1 < slideBlocks.length }
+					prevEnabled={ currentItemIndex + 1 > 1 }
+					setCurrentPage={ ( page ) => {
+						setCurrentItemIndex( page - 1 );
+					} }
+					totalPages={ slideBlocks.length }
+				/>
+			</div>
+		</div>
+	);
+}

--- a/src/blocks/report-archive/editor.scss
+++ b/src/blocks/report-archive/editor.scss
@@ -1,0 +1,8 @@
+
+.wp-block-wmf-reports-report-archive .block-editor-block-list__layout > .wp-block[data-align="full"] {
+	max-width: 100%;
+
+	.wp-block:not([data-align="full"]) {
+		max-width: 960px;
+	}
+}

--- a/src/blocks/report-archive/index.js
+++ b/src/blocks/report-archive/index.js
@@ -1,0 +1,34 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit.js';
+import metadata from './block.json';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+	save: () => <InnerBlocks.Content />,
+} );
+
+// Block HMR boilerplate.
+if ( module.hot ) {
+	module.hot.accept();
+	const { deregister, refresh } = require( '../../helpers/hot-blocks.js' );
+	module.hot.dispose( deregister( metadata.name ) );
+	refresh( metadata.name, module.hot.data );
+}

--- a/src/blocks/report-archive/render.php
+++ b/src/blocks/report-archive/render.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
+ */
+
+?>
+
+<div <?php echo get_block_wrapper_attributes( [ 'class' => 'report-archive carousel alignfull' ] ); ?>>
+	<div class="carousel-wrapper">
+		<div class="carousel__track-outer">
+			<div class="carousel__track">
+				<?php echo $content; ?>
+			</div>
+		</div>
+		<div class="carousel__buttons-wrapper">
+			<div class="carousel__buttons alignwide">
+				<button id="report-back" class="carousel__button carousel__button--back"><span class="screen-reader-text"><?php esc_html_e( 'Previous Report', 'wmf-reports' ); ?></span></button>
+				<button id="report-forward" class="carousel__button carousel__button--forward"><span class="screen-reader-text"><?php esc_html_e( 'Next Report', 'wmf-reports' ); ?></span></button>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/blocks/report-archive/view.js
+++ b/src/blocks/report-archive/view.js
@@ -1,0 +1,110 @@
+const reports = document.getElementsByClassName(
+	'wp-block-wmf-reports-report'
+);
+const backButton = document.getElementById( 'report-back' );
+const forwardButton = document.getElementById( 'report-forward' );
+const track = document.querySelector( '.carousel__track' );
+const slideWidth = 240;
+const gap = 32;
+const slideCount = reports.length;
+
+const slides = document.querySelectorAll( '.carousel__track .carousel__slide' );
+const lastSlide = document.querySelector(
+	'.carousel__track .carousel__slide:last-of-type'
+);
+
+const lastSlideClone = lastSlide.cloneNode( true );
+lastSlideClone.setAttribute( 'aria-hidden', true );
+
+Array.from( slides ).forEach( ( slide ) => {
+	const cloneSlide = slide.cloneNode( true );
+	cloneSlide.setAttribute( 'aria-hidden', true );
+	track.appendChild( cloneSlide );
+} );
+
+track.prepend( lastSlideClone );
+
+let wmfReportIndex = 0;
+let wmfReportPreviousIndex = 0;
+let doingAnimation = false;
+let touchstartX = 0;
+let touchendX = 0;
+
+const setMarginOffset = ( offset, animate = true ) => {
+	if ( doingAnimation ) {
+		return;
+	}
+	doingAnimation = true;
+	if ( animate ) {
+		track.classList.add( 'animate' );
+	}
+	track.style.marginLeft = -offset + 'px';
+	setTimeout( () => {
+			track.classList.remove( 'animate' );
+			doingAnimation = false;
+		},
+		animate ? 500 : 1
+	);
+};
+
+const animateSlider = ( currentItemIndex ) => {
+	let offset = slideWidth / 2;
+
+	if ( wmfReportIndex === slideCount - 1 && wmfReportPreviousIndex === 0 ) {
+		offset = offset + slideCount * ( slideWidth + gap );
+		setMarginOffset( offset, false );
+		setTimeout( () => {
+			offset = slideWidth / 2 + ( slideCount - 1 ) * ( slideWidth + gap );
+			setMarginOffset( offset );
+		}, 1 );
+		return;
+	}
+
+	if ( wmfReportIndex === 0 && wmfReportPreviousIndex === slideCount - 1 ) {
+		offset = offset + slideCount * ( slideWidth + gap );
+		setMarginOffset( offset );
+		setTimeout( () => {
+			offset = slideWidth / 2;
+			setMarginOffset( offset, false );
+		}, 500 );
+		return;
+	}
+
+	offset = offset + currentItemIndex * ( slideWidth + gap );
+	setMarginOffset( offset );
+};
+
+// Init slide width.
+setMarginOffset( slideWidth / 2 );
+
+backButton.addEventListener( 'click', () => {
+	wmfReportPreviousIndex = wmfReportIndex;
+	wmfReportIndex = wmfReportIndex - 1 < 0 ? slideCount - 1 : wmfReportIndex - 1;
+	animateSlider( wmfReportIndex );
+} );
+
+forwardButton.addEventListener( 'click', () => {
+	wmfReportPreviousIndex = wmfReportIndex;
+	wmfReportIndex =
+		wmfReportIndex + 1 > slideCount - 1 ? 0 : wmfReportIndex + 1;
+	animateSlider( wmfReportIndex );
+} );
+
+function checkDirection() {
+	if ( touchendX < touchstartX ) {
+		forwardButton.click();
+	}
+
+	if ( touchendX > touchstartX ) {
+		backButton.click();
+	}
+}
+
+document.addEventListener( 'touchstart', ( e ) => {
+	touchstartX = e.changedTouches[ 0 ].screenX;
+} );
+
+document.addEventListener( 'touchend', ( e ) => {
+	touchendX = e.changedTouches[ 0 ].screenX;
+	checkDirection()
+} );

--- a/src/blocks/report-archive/view.js
+++ b/src/blocks/report-archive/view.js
@@ -106,5 +106,5 @@ document.addEventListener( 'touchstart', ( e ) => {
 
 document.addEventListener( 'touchend', ( e ) => {
 	touchendX = e.changedTouches[ 0 ].screenX;
-	checkDirection()
+	checkDirection();
 } );

--- a/src/blocks/report-archive/view.js
+++ b/src/blocks/report-archive/view.js
@@ -39,7 +39,8 @@ const setMarginOffset = ( offset, animate = true ) => {
 		track.classList.add( 'animate' );
 	}
 	track.style.marginLeft = -offset + 'px';
-	setTimeout( () => {
+	setTimeout(
+		() => {
 			track.classList.remove( 'animate' );
 			doingAnimation = false;
 		},
@@ -79,7 +80,8 @@ setMarginOffset( slideWidth / 2 );
 
 backButton.addEventListener( 'click', () => {
 	wmfReportPreviousIndex = wmfReportIndex;
-	wmfReportIndex = wmfReportIndex - 1 < 0 ? slideCount - 1 : wmfReportIndex - 1;
+	wmfReportIndex =
+		wmfReportIndex - 1 < 0 ? slideCount - 1 : wmfReportIndex - 1;
 	animateSlider( wmfReportIndex );
 } );
 
@@ -100,11 +102,11 @@ function checkDirection() {
 	}
 }
 
-document.addEventListener( 'touchstart', ( e ) => {
+track.addEventListener( 'touchstart', ( e ) => {
 	touchstartX = e.changedTouches[ 0 ].screenX;
 } );
 
-document.addEventListener( 'touchend', ( e ) => {
+track.addEventListener( 'touchend', ( e ) => {
 	touchendX = e.changedTouches[ 0 ].screenX;
 	checkDirection();
 } );

--- a/src/blocks/report/block.json
+++ b/src/blocks/report/block.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wmf-reports/report",
+	"version": "0.1.0",
+	"title": "Report",
+	"category": "widgets",
+	"icon": "image-flip-horizontal",
+	"description": "",
+	"parent": [ "wmf-reports/report-archive" ],
+	"example": {},
+	"supports": {
+		"html": false
+	},
+	"textdomain": "wmf-reports",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"render": "file:./render.php"
+}

--- a/src/blocks/report/block.json
+++ b/src/blocks/report/block.json
@@ -14,6 +14,5 @@
 	},
 	"textdomain": "wmf-reports",
 	"editorScript": "file:./index.js",
-	"editorStyle": "file:./index.css",
 	"render": "file:./render.php"
 }

--- a/src/blocks/report/edit.js
+++ b/src/blocks/report/edit.js
@@ -1,0 +1,82 @@
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+// eslint-disable-next-line import/no-unresolved
+import './editor.scss';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @param {Object}   props               Block Props.
+ * @param {Object}   props.attributes    Block Attributes.
+ * @param {number}   props.clientId      Block ClientId.
+ * @param {Function} props.setAttributes Set Block Attributes.
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {Element} Element to render.
+ */
+export default function Edit() {
+	return (
+		<div
+			{ ...useBlockProps( {
+				className: 'carousel__slide',
+			} ) }
+		>
+			<InnerBlocks
+				template={ [
+					[
+						'core/image',
+						{
+							className:
+								'is-style-default wp-block-wmf-reports-report__image',
+							height: '300px',
+							id: 74197,
+							lightbox: {
+								className:
+									'is-style-default wp-block-wmf-reports-report__image',
+								enabled: false,
+								id: 74197,
+								linkDestination: 'none',
+								scale: 'cover',
+								sizeSlug: 'full',
+								url: '/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png',
+							},
+							linkDestination: 'none',
+							scale: 'cover',
+							sizeSlug: 'full',
+							url: '/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png',
+							width: '240px',
+						},
+					],
+					[
+						'core/paragraph',
+						{
+							className: 'wp-block-wmf-reports-report__date',
+							content: '<strong>2023</strong>',
+							style: {
+								elements: {
+									link: {
+										color: {
+											text: 'var:preset|color|base10',
+										},
+									},
+								},
+							},
+							textColor: 'base10',
+						},
+					],
+					[
+						'core/heading',
+						{
+							className:
+								'wp-block-wmf-reports-report__title is-style-default',
+							content:
+								'<a href="#"><strong>The people behind a year of impact around the world</strong></a>',
+							level: 3,
+						},
+					],
+				] }
+			/>
+		</div>
+	);
+}

--- a/src/blocks/report/edit.js
+++ b/src/blocks/report/edit.js
@@ -7,10 +7,6 @@ import './editor.scss';
  * The edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.
  *
- * @param {Object}   props               Block Props.
- * @param {Object}   props.attributes    Block Attributes.
- * @param {number}   props.clientId      Block ClientId.
- * @param {Function} props.setAttributes Set Block Attributes.
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
  *
  * @return {Element} Element to render.

--- a/src/blocks/report/edit.js
+++ b/src/blocks/report/edit.js
@@ -1,8 +1,5 @@
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-// eslint-disable-next-line import/no-unresolved
-import './editor.scss';
-
 /**
  * The edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.

--- a/src/blocks/report/index.js
+++ b/src/blocks/report/index.js
@@ -1,0 +1,34 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit.js';
+import metadata from './block.json';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+	save: () => <InnerBlocks.Content />,
+} );
+
+// Block HMR boilerplate.
+if ( module.hot ) {
+	module.hot.accept();
+	const { deregister, refresh } = require( '../../helpers/hot-blocks.js' );
+	module.hot.dispose( deregister( metadata.name ) );
+	refresh( metadata.name, module.hot.data );
+}

--- a/src/blocks/report/render.php
+++ b/src/blocks/report/render.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
+ */
+?>
+
+<div <?php echo get_block_wrapper_attributes( [ 'class' => 'carousel__slide' ]); ?>>
+	<?php echo $content; ?>
+</div>

--- a/src/blocks/stories/render.php
+++ b/src/blocks/stories/render.php
@@ -29,15 +29,15 @@
 		</div>
 	</div>
 	<div class="stories__categories-buttons alignwide">
-		<button id="carousel-slide-back" class="carousel__button carousel__button--back"><span class="screen-reader-text"><?php esc_html_e( 'Previous Map Marker', 'wmf-reports' ); ?></span></button>
-		<button id="carousel-slide-forward" class="carousel__button carousel__button--forward"><span class="screen-reader-text"><?php esc_html_e( 'Next Map Marker', 'wmf-reports' ); ?></span></button>
+		<button id="carousel-slide-back" class="carousel__button carousel__button--back"><span class="screen-reader-text"><?php esc_html_e( 'Previous Story', 'wmf-reports' ); ?></span></button>
+		<button id="carousel-slide-forward" class="carousel__button carousel__button--forward"><span class="screen-reader-text"><?php esc_html_e( 'Next Story', 'wmf-reports' ); ?></span></button>
 	</div>
 	<div class="carousel-wrapper">
 		<?php echo $content; ?>
 		<div class="carousel__buttons-wrapper">
 			<div class="carousel__buttons alignwide">
-				<button id="carousel-back" class="carousel__button carousel__button--back"><span class="screen-reader-text"><?php esc_html_e( 'Previous Map Marker', 'wmf-reports' ); ?></span></button>
-				<button id="carousel-forward" class="carousel__button carousel__button--forward"><span class="screen-reader-text"><?php esc_html_e( 'Next Map Marker', 'wmf-reports' ); ?></span></button>
+				<button id="carousel-back" class="carousel__button carousel__button--back"><span class="screen-reader-text"><?php esc_html_e( 'Previous Story', 'wmf-reports' ); ?></span></button>
+				<button id="carousel-forward" class="carousel__button carousel__button--forward"><span class="screen-reader-text"><?php esc_html_e( 'Next Story', 'wmf-reports' ); ?></span></button>
 			</div>
 		</div>
 	</div>

--- a/src/blocks/stories/view.js
+++ b/src/blocks/stories/view.js
@@ -23,7 +23,7 @@ const animateSlider = ( currentItemIndex ) => {
 	)?.[ 0 ];
 	const activeCategory = document.querySelector( '.category-slide.active' );
 	const lastSlide = document.querySelector( '.category-slide:last-child' );
-	const currentOffset = track.style.marginLeft || 0;
+	const currentOffset = parseInt( track.style.marginLeft ) || 0;
 
 	const wrapperPosition = wrapper?.getBoundingClientRect();
 	const categoryPosition = activeCategory?.getBoundingClientRect();
@@ -32,7 +32,7 @@ const animateSlider = ( currentItemIndex ) => {
 	// calculate the position of the category slide.
 
 	// If there are not enough items to trigger scrolling, return.
-	if ( lastSlidePosition.right + currentOffset < wrapperPosition.right ) {
+	if ( lastSlidePosition.right - currentOffset < wrapperPosition.right ) {
 		setMarginOffset( 0 );
 		document.querySelector( '.stories__categories-buttons' ).style.display =
 			'none';
@@ -49,8 +49,7 @@ const animateSlider = ( currentItemIndex ) => {
 	if ( currentItemIndex === slideCount - 1 ) {
 		// Get width of slide.
 		const slideWidth = categoryPosition.right - categoryPosition.left;
-		const positionOfSlide =
-			categoryPosition.left - parseInt( currentOffset );
+		const positionOfSlide = categoryPosition.left - currentOffset;
 		const newPosition =
 			wrapperPosition.right - ( positionOfSlide + slideWidth );
 		setMarginOffset( newPosition );
@@ -62,8 +61,7 @@ const animateSlider = ( currentItemIndex ) => {
 			'.category-slide:first-child'
 		);
 		const slideWidth = categoryPosition.right - categoryPosition.left;
-		const positionOfSlide =
-			categoryPosition.left - parseInt( currentOffset );
+		const positionOfSlide = categoryPosition.left - currentOffset;
 		const wrapperWidth = wrapperPosition.right - wrapperPosition.left;
 		const halfWrapperWidth = wrapperWidth / 2;
 		const newPosition =
@@ -74,8 +72,7 @@ const animateSlider = ( currentItemIndex ) => {
 
 		// If its going to take our first slide too far right, set the position 0.
 		const firstSlidePosition = firstSlide?.getBoundingClientRect();
-		const firstSlideOffset =
-			firstSlidePosition.left - parseInt( currentOffset );
+		const firstSlideOffset = firstSlidePosition.left - currentOffset;
 		const firstSlideNewPosition = firstSlideOffset + newPosition;
 
 		if ( firstSlideNewPosition > wrapperPosition.left ) {
@@ -84,8 +81,7 @@ const animateSlider = ( currentItemIndex ) => {
 		}
 
 		// If its going to take our last slide too far left, set position of last slide.
-		const lastSlideOffset =
-			lastSlidePosition.right - parseInt( currentOffset );
+		const lastSlideOffset = lastSlidePosition.right - currentOffset;
 		const lastSlideNewPosition = lastSlideOffset + newPosition;
 
 		if ( lastSlideNewPosition < wrapperPosition.right ) {

--- a/src/blocks/stories/view.js
+++ b/src/blocks/stories/view.js
@@ -7,12 +7,9 @@ const forwardCategoryButton = document.getElementById(
 	'carousel-slide-forward'
 );
 const slideCount = stories.length;
+const track = document.getElementsByClassName( 'stories__categories' )?.[ 0 ];
 
 const setMarginOffset = ( offset ) => {
-	const track = document.getElementsByClassName(
-		'stories__categories'
-	)?.[ 0 ];
-
 	track.style.marginLeft = offset + 'px';
 };
 
@@ -23,9 +20,6 @@ let touchendX = 0;
 const animateSlider = ( currentItemIndex ) => {
 	const wrapper = document.getElementsByClassName(
 		'stories__categories-wrapper'
-	)?.[ 0 ];
-	const track = document.getElementsByClassName(
-		'stories__categories'
 	)?.[ 0 ];
 	const activeCategory = document.querySelector( '.category-slide.active' );
 	const lastSlide = document.querySelector( '.category-slide:last-child' );
@@ -272,11 +266,11 @@ function checkDirection() {
 	}
 }
 
-document.addEventListener( 'touchstart', ( e ) => {
+track.addEventListener( 'touchstart', ( e ) => {
 	touchstartX = e.changedTouches[ 0 ].screenX;
 } );
 
-document.addEventListener( 'touchend', ( e ) => {
+track.addEventListener( 'touchend', ( e ) => {
 	touchendX = e.changedTouches[ 0 ].screenX;
 	checkDirection();
 } );

--- a/src/blocks/stories/view.js
+++ b/src/blocks/stories/view.js
@@ -10,24 +10,26 @@ const slideCount = stories.length;
 
 const setMarginOffset = ( offset ) => {
 	const track = document.getElementsByClassName(
-		'stories__categories-wrapper'
+		'stories__categories'
 	)?.[ 0 ];
 
-	track.scrollTo( {
-		left: -offset,
-		behavior: 'smooth',
-	} );
+	track.style.marginLeft = offset + 'px';
 };
 
 let processingAnimation = false;
+let touchstartX = 0;
+let touchendX = 0;
 
 const animateSlider = ( currentItemIndex ) => {
 	const wrapper = document.getElementsByClassName(
 		'stories__categories-wrapper'
 	)?.[ 0 ];
+	const track = document.getElementsByClassName(
+		'stories__categories'
+	)?.[ 0 ];
 	const activeCategory = document.querySelector( '.category-slide.active' );
 	const lastSlide = document.querySelector( '.category-slide:last-child' );
-	const currentOffset = -wrapper.scrollLeft || 0;
+	const currentOffset = track.style.marginLeft || 0;
 
 	const wrapperPosition = wrapper?.getBoundingClientRect();
 	const categoryPosition = activeCategory?.getBoundingClientRect();
@@ -36,7 +38,7 @@ const animateSlider = ( currentItemIndex ) => {
 	// calculate the position of the category slide.
 
 	// If there are not enough items to trigger scrolling, return.
-	if ( lastSlidePosition.right < wrapperPosition.right ) {
+	if ( lastSlidePosition.right + currentOffset < wrapperPosition.right ) {
 		setMarginOffset( 0 );
 		document.querySelector( '.stories__categories-buttons' ).style.display =
 			'none';
@@ -188,12 +190,15 @@ const setSlide = ( id ) => {
 				setTimeout( () => {
 					nextStoryInfoBox.style.opacity = 1;
 
-					storyInfoBox.style.opacity = 0;
 					storyInfoBox.style.height =
 						nextStoryInfoBox.offsetHeight + 'px';
 
 					processingAnimation = true;
 				}, 2 );
+
+				setTimeout( () => {
+					storyInfoBox.style.opacity = 0;
+				}, 250 );
 
 				setTimeout( () => {
 					nextStoryInfoBox.style.height = null;
@@ -255,4 +260,23 @@ Array.from( categorySlides ).forEach( ( categorySlide, index ) => {
 		const nextIndex = index + 1 > stories.length - 1 ? 0 : index + 1;
 		setSlide( nextIndex );
 	} );
+} );
+
+function checkDirection() {
+	if ( touchendX < touchstartX ) {
+		forwardButton.click();
+	}
+
+	if ( touchendX > touchstartX ) {
+		backButton.click();
+	}
+}
+
+document.addEventListener( 'touchstart', ( e ) => {
+	touchstartX = e.changedTouches[ 0 ].screenX;
+} );
+
+document.addEventListener( 'touchend', ( e ) => {
+	touchendX = e.changedTouches[ 0 ].screenX;
+	checkDirection();
 } );

--- a/src/editor.scss
+++ b/src/editor.scss
@@ -90,15 +90,18 @@
 // stylelint-disable-next-line  no-duplicate-selectors
 .editor-styles-wrapper.single-wmf-report {
 
-	.accordion-item__title::after {
-		background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAyMiAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMSA5LjU4NTg2TDIwLjI5MjkgMC4yOTI5NjlMMjEuNzA3MSAxLjcwNzE4TDExIDEyLjQxNDNMMC4yOTI4NzcgMS43MDcxOEwxLjcwNzA5IDAuMjkyOTY5TDExIDkuNTg1ODZaIiBmaWxsPSJibGFjayIvPgo8L3N2Zz4K) center center no-repeat;
-		content: " ";
-		display: inline-block;
-		height: 48px;
-		width: 48px;
-		vertical-align: middle;
-		transform: none;
-		border: 1px solid #aaa;
-		border-radius: 50%;
+	.wp-block-wmf-reports-accordion {
+
+		.accordion-item__title::after {
+			background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAyMiAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMSA5LjU4NTg2TDIwLjI5MjkgMC4yOTI5NjlMMjEuNzA3MSAxLjcwNzE4TDExIDEyLjQxNDNMMC4yOTI4NzcgMS43MDcxOEwxLjcwNzA5IDAuMjkyOTY5TDExIDkuNTg1ODZaIiBmaWxsPSJibGFjayIvPgo8L3N2Zz4K) center center no-repeat;
+			content: " ";
+			display: inline-block;
+			height: 48px;
+			width: 48px;
+			vertical-align: middle;
+			transform: none;
+			border: 1px solid #aaa;
+			border-radius: 50%;
+		}
 	}
 }

--- a/src/features/accordion.js
+++ b/src/features/accordion.js
@@ -1,0 +1,15 @@
+document.addEventListener( 'DOMContentLoaded', () => {
+	const accordions = document.querySelectorAll(
+		'.single-wmf-report .wp-block-shiro-accordion'
+	);
+
+	if ( ! accordions ) {
+		return;
+	}
+
+	Array.from( accordions ).forEach( ( accordion ) => {
+		accordion
+			.querySelector( '.accordion-item' )
+			.setAttribute( 'aria-expanded', '' );
+	} );
+} );

--- a/src/frontend-global.scss
+++ b/src/frontend-global.scss
@@ -11,8 +11,10 @@
 @import "styles/core-heading-report-section-heading";
 @import "styles/core-group-report-overlapping-callout";
 @import "styles/core-image";
+@import "styles/report-archive";
 @import "styles/map";
 @import "styles/stories";
+
 
 /* Patterns */
 @import "patterns/accordion";

--- a/src/frontend-global.scss
+++ b/src/frontend-global.scss
@@ -21,6 +21,7 @@
 @import "patterns/carousel";
 @import "patterns/donate";
 @import "patterns/donors";
+@import "patterns/financial-statements";
 @import "patterns/hero";
 @import "patterns/leadership";
 @import "patterns/letter-from-the-ceo";

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -8,3 +8,6 @@ import './formats/countup-number/view';
 
 // Frontend logic that isn't tied to a custom block.
 import './features/core-group-report-overlapping-callout';
+
+// Open accordion first items by default.
+import './features/accordion';

--- a/src/patterns/accordion.scss
+++ b/src/patterns/accordion.scss
@@ -71,3 +71,88 @@
 		}
 	}
 }
+
+.wp-block-wmf-reports-accordion--alt {
+	margin-bottom: 2rem;
+
+	.accordion-item {
+		background: #fff;
+		border: 1px solid #000;
+		margin-bottom: 1rem;
+		padding: 1rem 0.5rem 1rem 1.5rem;
+		position: relative;
+
+		&::before {
+			background-color: #ff6801;
+			border-right: 1px solid #000;
+			content: "";
+			height: 100%;
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 0.5rem;
+		}
+	}
+
+	/* stylelint-disable no-descending-specificity */
+	.accordion-item__title::after {
+		background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAyMiAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMSA5LjU4NTg2TDIwLjI5MjkgMC4yOTI5NjlMMjEuNzA3MSAxLjcwNzE4TDExIDEyLjQxNDNMMC4yOTI4NzcgMS43MDcxOEwxLjcwNzA5IDAuMjkyOTY5TDExIDkuNTg1ODZaIiBmaWxsPSJibGFjayIvPgo8L3N2Zz4K) center center no-repeat;
+		content: " ";
+		display: inline-block;
+		height: 0.8rem;
+		right: 0.3rem;
+		top: 0.3rem;
+		transform: none;
+		vertical-align: middle;
+		width: 0.8rem;
+	}
+
+	.accordion-item[aria-expanded] .accordion-item__title::after {
+		transform: rotate(180deg);
+	}
+
+	.accordion-item__title-text {
+		font-size: 1rem;
+		font-weight: 700;
+		margin-right: 5rem;
+
+		mark {
+			position: absolute;
+			right: 2rem;
+			top: 0;
+		}
+	}
+
+	.accordion-item__content {
+		font-size: $font-size-base;
+	}
+	/* stylelint-enable no-descending-specificity */
+}
+
+/* stylelint-disable no-descending-specificity */
+.wmf-pattern-financial-statements {
+
+	.wp-block-wmf-reports-accordion--alt {
+
+		.wp-block-shiro-accordion-item:nth-of-type(1) .accordion-item::before,
+		.accordion-item:nth-of-type(1)::before {
+			background-color: #9b51df;
+		}
+
+		.wp-block-shiro-accordion-item:nth-of-type(2) .accordion-item::before,
+		.accordion-item:nth-of-type(2)::before {
+			background-color: #970203;
+		}
+
+		.wp-block-shiro-accordion-item:nth-of-type(3) .accordion-item::before,
+		.accordion-item:nth-of-type(3)::before {
+			background-color: #ff6801;
+		}
+
+		.wp-block-shiro-accordion-item:nth-of-type(4) .accordion-item::before,
+		.accordion-item:nth-of-type(4)::before {
+			background-color: #fcb900;
+		}
+	}
+}
+/* stylelint-enable no-descending-specificity */

--- a/src/patterns/carousel.scss
+++ b/src/patterns/carousel.scss
@@ -94,6 +94,40 @@
 	}
 }
 
+.wp-block-wmf-reports-report-archive.carousel {
+	.carousel__buttons {
+		margin: 2rem auto 2rem auto;
+		max-width: $width-breakpoint-wide;
+		text-align: right;
+	}
+
+	button.carousel__button {
+		background-color: #fff;
+		// stylelint-disable-next-line function-url-quotes
+		background-image: url('data:image/svg+xml,<svg width="13" height="22" viewBox="0 0 13 22" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M9.5858 11L0.292908 1.70712L1.70712 0.292908L12.4142 11L1.70712 21.7071L0.292908 20.2929L9.5858 11Z" fill="black"/></svg>');
+		background-position: 55% 50%;
+		background-repeat: no-repeat;
+		border: 1px solid #aaa;
+		border-radius: 100%;
+		cursor: pointer;
+		height: 48px;
+		margin-left: 0.5rem;
+		width: 48px;
+
+		&--back {
+			transform: scaleX(-1);
+		}
+
+		&:hover {
+			background-color: #ccc;
+		}
+
+		&:focus {
+			border-radius: 100%;
+		}
+	}
+}
+
 .wmf-pattern-reports-carousel-slide {
 	font-family: $font-family-base;
 	font-size: $font-size-base;

--- a/src/patterns/carousel.scss
+++ b/src/patterns/carousel.scss
@@ -80,15 +80,19 @@
 			display: block;
 
 			#carousel-slide-back {
+				height: 40px;
 				left: -6rem;
 				position: absolute;
 				top: -5.5rem;
+				width: 40px;
 			}
 
 			#carousel-slide-forward {
+				height: 40px;
 				position: absolute;
 				right: -6rem;
 				top: -5.5rem;
+				width: 40px;
 			}
 		}
 	}

--- a/src/patterns/carousel.scss
+++ b/src/patterns/carousel.scss
@@ -99,12 +99,15 @@
 }
 
 .wp-block-wmf-reports-report-archive.carousel {
+
+	// stylelint-disable-next-line  no-descending-specificity
 	.carousel__buttons {
 		margin: 2rem auto 2rem auto;
 		max-width: $width-breakpoint-wide;
 		text-align: right;
 	}
 
+	// stylelint-disable-next-line  no-descending-specificity
 	button.carousel__button {
 		background-color: #fff;
 		// stylelint-disable-next-line function-url-quotes

--- a/src/patterns/financial-statements.scss
+++ b/src/patterns/financial-statements.scss
@@ -1,0 +1,7 @@
+.wmf-pattern-financial-statements {
+	&__score {
+		.wp-block-image {
+			margin-bottom: 0.5rem;
+		}
+	}
+}

--- a/src/patterns/financial-statements.scss
+++ b/src/patterns/financial-statements.scss
@@ -1,5 +1,7 @@
 .wmf-pattern-financial-statements {
+
 	&__score {
+
 		.wp-block-image {
 			margin-bottom: 0.5rem;
 		}

--- a/src/styles/report-archive.scss
+++ b/src/styles/report-archive.scss
@@ -3,7 +3,7 @@
 
 	.carousel__track-outer {
 		margin: auto;
-		max-width: calc( $width-breakpoint-desktop-extrawide * 2 );
+		max-width: calc($width-breakpoint-desktop-extrawide * 2);
 		scrollbar-width: none;
 		overflow: hidden;
 	}
@@ -12,6 +12,7 @@
 		display: flex;
 		gap: 2rem;
 		width: max-content;
+
 		&.animate {
 			transition: all 0.5s;
 		}
@@ -23,18 +24,22 @@
 	max-width: 240px;
 	width: 240px;
 
+	// stylelint-disable-next-line  no-descending-specificity
 	.wp-block-wmf-reports-report__image {
 		margin-bottom: 2rem;
 
+		// stylelint-disable-next-line  no-descending-specificity
 		img {
 			border-bottom-right-radius: 2rem;
 		}
 	}
 
+	// stylelint-disable-next-line  no-descending-specificity
 	.wp-block-wmf-reports-report__date {
 		margin-bottom: 0.5rem;
 	}
 
+	// stylelint-disable-next-line  no-descending-specificity
 	h3.wp-block-wmf-reports-report__title,
 	.wp-block-wmf-reports-report__title {
 		line-height: 1.2;

--- a/src/styles/report-archive.scss
+++ b/src/styles/report-archive.scss
@@ -1,0 +1,37 @@
+.wp-block-wmf-reports-report-archive.carousel {
+	margin-top: 2rem;
+
+	.carousel__track-outer {
+		scrollbar-width: none;
+		overflow: scroll;
+	}
+
+	.carousel__track {
+		display: flex;
+		gap: 2rem;
+		width: max-content;
+	}
+}
+
+.block-editor-block-list__layout > .wp-block.wp-block-wmf-reports-report,
+.wp-block-wmf-reports-report {
+	max-width: 240px;
+	width: 240px;
+
+	.wp-block-wmf-reports-report__image {
+		margin-bottom: 2rem;
+
+		img {
+			border-bottom-right-radius: 2rem;
+		}
+	}
+
+	.wp-block-wmf-reports-report__date {
+		margin-bottom: 0.5rem;
+	}
+
+	h3.wp-block-wmf-reports-report__title,
+	.wp-block-wmf-reports-report__title {
+		line-height: 1.2;
+	}
+}

--- a/src/styles/report-archive.scss
+++ b/src/styles/report-archive.scss
@@ -2,14 +2,19 @@
 	margin-top: 2rem;
 
 	.carousel__track-outer {
+		margin: auto;
+		max-width: calc( $width-breakpoint-desktop-extrawide * 2 );
 		scrollbar-width: none;
-		overflow: scroll;
+		overflow: hidden;
 	}
 
 	.carousel__track {
 		display: flex;
 		gap: 2rem;
 		width: max-content;
+		&.animate {
+			transition: all 0.5s;
+		}
 	}
 }
 

--- a/src/styles/stories.scss
+++ b/src/styles/stories.scss
@@ -19,12 +19,11 @@
 }
 
 .stories {
-
 	&.carousel &__categories-wrapper.alignwide {
 		margin: auto;
 		margin-bottom: 2rem;
 		max-width: calc($width-breakpoint-wide + 4rem) !important;
-		overflow: scroll;
+		overflow: hidden;
 		padding-left: 0;
 		padding-right: 0;
 		padding-top: 2px;

--- a/src/styles/stories.scss
+++ b/src/styles/stories.scss
@@ -19,6 +19,7 @@
 }
 
 .stories {
+
 	&.carousel &__categories-wrapper.alignwide {
 		margin: auto;
 		margin-bottom: 2rem;


### PR DESCRIPTION
- Creates a block for the previous reports, which will infinitely scroll.
- Also addresses bugs in other carousels. 

To test:
- Insert the `Report Archive` block (or better still the Previous Reports Pattern)
- Add multiple slides and populate their contents. You will need to add a slide for each previous annual report.
- View the carousel on the front end, confirm that the infinite scroll works as expected, and the carousel will slide with touch on mobile.

Demo:
https://cln.sh/b0Xn9F3t1CzXBHtqlgkd

