### PR TITLE
#979: "Thank you" text animation block

### DIFF
--- a/src/blocks/thank-you/block.json
+++ b/src/blocks/thank-you/block.json
@@ -15,12 +15,15 @@
 		"lines": {
 			"type": "array",
 			"default": [
-				"Thank You!",
-				"Merci!",
-				"धन्यवाद्",
-				"Gracias!",
-				"Спасибо!",
-				"ありがとう"
+				"Merci",
+				"धन्यवाद",
+				"Gracias",
+				"ありがとう",
+				"شكراً",
+				"Danke",
+				"Asante",
+				"շնորհակալություն",
+				"Thank you!"
 			]
 		}
 	},

--- a/src/blocks/thank-you/block.json
+++ b/src/blocks/thank-you/block.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wmf-reports/thank-you",
+	"version": "0.1.0",
+	"title": "Thank-You Text",
+	"textdomain": "wmf-reports",
+	"category": "widgets",
+	"icon": "heart",
+	"description": "Animated vertical text carousel to display a multilingual message of gratitude.",
+	"supports": {
+		"html": false
+	},
+	"attributes": {
+		"lines": {
+			"type": "array",
+			"default": [
+				"Thank You!",
+				"Merci!",
+				"धन्यवाद्",
+				"Gracias!",
+				"Спасибо!",
+				"ありがとう"
+			]
+		}
+	},
+	"editorScript": "file:./index.js",
+	"render": "file:./render.php",
+	"style": "file:./style-index.css",
+	"viewScript": "file:./view.js"
+}

--- a/src/blocks/thank-you/edit.js
+++ b/src/blocks/thank-you/edit.js
@@ -1,0 +1,45 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, RichText } from '@wordpress/block-editor';
+import { useCallback } from 'react';
+
+import '../../types';
+
+/**
+ * The edit function represents what the editor will render when the block is used.
+ *
+ * @param {EditComponentProps} props React component props.
+ * @return {Element} Element to render.
+ */
+export default function Edit( { isSelected, attributes, setAttributes } ) {
+	const updateLine = useCallback(
+		( line, idx ) => {
+			const lines = [ ...attributes.lines ];
+			lines[ idx ] = line;
+			setAttributes( { lines } );
+		},
+		[ attributes.lines, setAttributes ]
+	);
+	return (
+		<p { ...useBlockProps() }>
+			{ isSelected
+				? attributes.lines.map( ( line, idx ) => (
+						<RichText
+							key={ line }
+							tagName="span"
+							className="wmf-thank-you-line"
+							value={ line }
+							allowedFormats={ [] }
+							onChange={ ( updatedLine ) =>
+								updateLine( updatedLine, idx )
+							}
+							placeholder={ __( 'Thank You!', 'wmf-reports' ) }
+						/>
+				  ) )
+				: attributes.lines.slice( 0, 4 ).map( ( line ) => (
+						<span key={ line } className="wmf-thank-you-line">
+							{ line }
+						</span>
+				  ) ) }
+		</p>
+	);
+}

--- a/src/blocks/thank-you/index.js
+++ b/src/blocks/thank-you/index.js
@@ -1,0 +1,20 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+/** @see https://www.npmjs.com/package/@wordpress/scripts#using-css */
+import './style.scss';
+
+import metadata from './block.json';
+import Edit from './edit.js';
+
+registerBlockType( metadata.name, {
+	...metadata,
+	edit: Edit,
+} );
+
+// Block HMR boilerplate.
+if ( module.hot ) {
+	module.hot.accept();
+	const { deregister, refresh } = require( '../../helpers/hot-blocks.js' );
+	module.hot.dispose( deregister( metadata.name ) );
+	refresh( metadata.name, module.hot.data );
+}

--- a/src/blocks/thank-you/render.php
+++ b/src/blocks/thank-you/render.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
+ */
+
+?>
+
+<?php if ( ! empty( $attributes['lines'] ) ) : ?>
+<p class="wp-block-wmf-reports-thank-you">
+	<?php
+	foreach ( $attributes['lines'] as $line ) {
+		if ( empty( $line ) ) {
+			continue;
+		}
+		echo sprintf(
+			'<span class="wmf-thank-you-line">%s</span>',
+			esc_html( $line )
+		);
+	}
+	?>
+</p>
+<?php endif; ?>

--- a/src/blocks/thank-you/style.scss
+++ b/src/blocks/thank-you/style.scss
@@ -1,0 +1,68 @@
+/**
+ * The following styles get applied both on the frontend and editor.
+ */
+
+.wp-block-wmf-reports-thank-you,
+.editor-styles-wrapper .wp-block-wmf-reports-thank-you {
+	--animation-duration: 500ms;
+	--text-size: 1.75rem;
+	--height: 2.125rem;
+
+	height: calc(var(--height) * 4);
+	overflow: hidden;
+
+	.wmf-thank-you-line {
+		display: block;
+		font-family: "Noto Sans", sans-serif;
+		font-size: var(--text-size);
+		font-weight: 700;
+		height: var(--height);
+		letter-spacing: -0.035rem;
+		line-height: 1;
+		transition: opacity var(--animation-duration), height var(--animation-duration);
+	}
+
+	// Make all text visible when block is selected.
+	&.is-selected {
+		height: auto;
+
+		.wmf-thank-you-line {
+			opacity: 1 !important;
+		}
+	}
+
+	// stylelint-disable no-descending-specificity
+	.wmf-thank-you-line:nth-of-type(1),
+	.wmf-thank-you-line:nth-of-type(2).fadein {
+		opacity: 1;
+	}
+
+	.wmf-thank-you-line:nth-of-type(2),
+	.wmf-thank-you-line:nth-of-type(3).fadein {
+		opacity: 0.5;
+	}
+
+	.wmf-thank-you-line:nth-of-type(3),
+	.wmf-thank-you-line:nth-of-type(4).fadein {
+		opacity: 0.2;
+	}
+
+	.wmf-thank-you-line:nth-of-type(4),
+	.wmf-thank-you-line:nth-of-type(5).fadein {
+		opacity: 0.1;
+	}
+
+	.wmf-thank-you-line:nth-of-type(5).fadein {
+		transition-duration: calc(1.5 * var(--animation-duration));
+		transition-delay: calc(0.2 * var(--animation-duration));
+	}
+
+	.wmf-thank-you-line:not(:nth-child(-n+4)),
+	.wmf-thank-you-line.fadeout {
+		opacity: 0;
+	}
+
+	.collapse {
+		height: 0;
+	}
+}

--- a/src/blocks/thank-you/view.js
+++ b/src/blocks/thank-you/view.js
@@ -1,0 +1,105 @@
+/**
+ * Use this file for JavaScript code that you want to run in the front-end
+ * on posts/pages that contain this block.
+ */
+const ANIMATION_DURATION = 500;
+
+/**
+ * Pause the animation of a specific widget.
+ *
+ * Used both to "reset" the animation if it gets re-initialized, and to
+ * disable active animations if prefers-reduced-motion setting changes.
+ *
+ * @param {HTMLDivElement} widget Container node.
+ */
+function pauseAnimation( widget ) {
+	const intervalId = widget.dataset.thankYouAnimation;
+	if ( ! isNaN( parseInt( intervalId, 10 ) ) ) {
+		clearInterval( intervalId );
+	}
+}
+
+/**
+ * Initialize the looping animation for a specific widget.
+ *
+ * @param {HTMLDivElement} widget Container node.
+ */
+function initWidget( widget ) {
+	// There can only be one! [animation per widget].
+	pauseAnimation( widget );
+	widget.dataset.thankYouAnimation = setInterval(
+		animate( widget ),
+		ANIMATION_DURATION * 4
+	);
+}
+
+/**
+ * Generate an interval function to loop the specified node.
+ *
+ * @param {HTMLDivElement} widget Container node.
+ * @return {Function} Animation interval function.
+ */
+const animate = ( widget ) => () => {
+	const lines = Array.from(
+		widget.querySelectorAll( '.wmf-thank-you-line' )
+	);
+
+	const firstLine = lines[ 0 ];
+	const lastLine = lines[ lines.length - 1 ];
+
+	// Fade out first line.
+	firstLine.classList.add( 'fadeout' );
+	setTimeout( () => {
+		// Collapse the now-hidden first line.
+		firstLine.classList.add( 'collapse' );
+		// Fade in each subsequent line of text as the first one collapses.
+		[ 1, 2, 3, 4 ].forEach( ( indexToFadeIn ) => {
+			if ( lines[ indexToFadeIn ] ) {
+				lines[ indexToFadeIn ].classList.add( 'fadein' );
+			}
+		} );
+	}, ANIMATION_DURATION * 0.75 );
+	setTimeout( () => {
+		// Move first line down to bottom, then reset all animation classes.
+		lastLine.after( firstLine );
+		firstLine.classList.remove( 'fadeout', 'collapse' );
+		Array.from( widget.querySelectorAll( '.fadein' ) ).forEach(
+			( line ) => {
+				line.classList.remove( 'fadein' );
+			}
+		);
+	}, ANIMATION_DURATION * 1.75 );
+};
+
+// Initialize!
+function initializeAll() {
+	const widgetSelector = '.wp-block-wmf-reports-thank-you';
+	const prefersReducedMotion = window.matchMedia(
+		'(prefers-reduced-motion: reduce)'
+	);
+
+	if ( ! prefersReducedMotion.matches ) {
+		// Only start if it does not conflict with user preferences.
+		document.querySelectorAll( widgetSelector ).forEach( initWidget );
+	}
+
+	// Play or pause animation as user setting changes.
+	prefersReducedMotion.addEventListener( 'change', () => {
+		if ( prefersReducedMotion.matches ) {
+			// Pause any in-progress animations.
+			document
+				.querySelectorAll( widgetSelector )
+				.forEach( pauseAnimation );
+		} else {
+			// Safe to initialize!
+			document.querySelectorAll( widgetSelector ).forEach( initWidget );
+		}
+	} );
+}
+
+// Kick if off.
+initializeAll();
+
+if ( module.hot ) {
+	module.hot.accept();
+}

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,14 @@
+/**
+ * We may not be using TypeScript, but we can still improve our intellesense by
+ * properly documenting complex objects.
+ */
+
+/**
+ * Reusable type for Edit component React props.
+ *
+ * @typedef {Object} EditComponentProps
+ * @property {Record<string, any>}                  attributes    Block attributes.
+ * @property {(attrs: Record<string, any>) => void} setAttributes Attribute setter function.
+ * @property {string}                               clientId      Transient block clientId.
+ * @property {bool}                                 isSelected    Whether this block is selected.
+ */


### PR DESCRIPTION
This PR implements a custom animation block for the "Thank You!" text animation

Editor view, unselected

<img width="768" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/fc3947eb-3266-43ef-9f1c-83d82d740156">

Editor view, selected

<img width="774" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/f81d0329-773b-4535-8546-7a478ce0e420">

Frontend view

![text-animation](https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/88d833b4-f624-443e-a223-20706e370658)

> [!NOTE]
> This block honors the "reduce motion" operating system preference
