### PR TITLE
#973: Implement table of contents styling

### DIFF
--- a/src/blocks/table-of-contents/frontend.scss
+++ b/src/blocks/table-of-contents/frontend.scss
@@ -5,19 +5,21 @@
  * Replace them with your own styles or remove the file completely.
  */
 
-.wp-block-wmf-reports-table-of-contents {
+.wp-block-wmf-reports-table-of-contents,
+.editor-styles-wrapper .wp-block-wmf-reports-table-of-contents {
 	ul {
 		padding-left: 1rem;
+		margin: 0;
 	}
 
 	li {
 		list-style-type: none;
 		margin-bottom: 0.5rem;
 
-		::marker {
-			color: var( --wp--preset--color--wmf-report-link-color );
-			font-size: 0.75rem;
+		&:last-child {
+			margin-bottom: 0;
 		}
+
 		&::before {
 			background-color: var( --wp--preset--color--wmf-report-link-color );
 			border-radius: 50%;

--- a/src/blocks/table-of-contents/frontend.scss
+++ b/src/blocks/table-of-contents/frontend.scss
@@ -6,5 +6,50 @@
  */
 
 .wp-block-wmf-reports-table-of-contents {
-	border-bottom: 1px dotted #777;
+	ul {
+		padding-left: 1rem;
+	}
+
+	li {
+		list-style-type: none;
+		margin-bottom: 0.5rem;
+
+		::marker {
+			color: var( --wp--preset--color--wmf-report-link-color );
+			font-size: 0.75rem;
+		}
+		&::before {
+			background-color: var( --wp--preset--color--wmf-report-link-color );
+			border-radius: 50%;
+			content: " ";
+			display: inline-block;
+			height: 4px;
+			margin: 0 0.75rem 0 -1rem;
+			vertical-align: middle;
+			width: 4px;
+		}
+
+		a {
+			font-size: 0.9375rem;
+			line-height: 1;
+		}
+	}
+
+	@media screen and (min-width: 782px) {
+		ul {
+			margin-left: 2rem;
+			padding-left: 2.875rem;
+			border-left: 1px solid var(--wp--preset--color--wmf-report-blue);
+		}
+		li {
+			&::before {
+				display: none;
+			}
+			a {
+				color: var(--wp--preset--color--wmf-report-blue);
+				font-size: 1.125rem;
+				font-weight: 700;
+			}
+		}
+	}
 }

--- a/src/blocks/table-of-contents/frontend.scss
+++ b/src/blocks/table-of-contents/frontend.scss
@@ -5,12 +5,9 @@
  * Replace them with your own styles or remove the file completely.
  */
 
-.wp-block-wmf-reports-table-of-contents,
-.editor-styles-wrapper .wp-block-wmf-reports-table-of-contents {
-	ul {
-		padding-left: 1rem;
-		margin: 0;
-	}
+.wp-block-wmf-reports-table-of-contents {
+	padding-left: 1rem;
+	margin: 0;
 
 	li {
 		list-style-type: none;
@@ -38,15 +35,15 @@
 	}
 
 	@media screen and (min-width: 782px) {
-		ul {
-			margin-left: 2rem;
-			padding-left: 2.875rem;
-			border-left: 1px solid var(--wp--preset--color--wmf-report-blue);
-		}
+		margin-left: 2rem;
+		padding-left: 2.875rem;
+		border-left: 1px solid var(--wp--preset--color--wmf-report-blue);
+
 		li {
 			&::before {
 				display: none;
 			}
+
 			a {
 				color: var(--wp--preset--color--wmf-report-blue);
 				font-size: 1.125rem;

--- a/src/blocks/table-of-contents/save.js
+++ b/src/blocks/table-of-contents/save.js
@@ -19,18 +19,16 @@ import { useBlockProps } from '@wordpress/block-editor';
  */
 export default function save( { attributes } ) {
 	return (
-		<nav { ...useBlockProps.save() }>
-			<ul>
-				{ ( JSON.parse( attributes.waypoints ) || [] ).map(
-					( waypoint ) => (
-						<li key={ `waypoint-${ waypoint.tocSlug }` }>
-							<a href={ `#${ waypoint.tocSlug }` }>
-								{ waypoint.tocLabel }
-							</a>
-						</li>
-					)
-				) }
-			</ul>
-		</nav>
+		<ul { ...useBlockProps.save() }>
+			{ ( JSON.parse( attributes.waypoints ) || [] ).map(
+				( waypoint ) => (
+					<li key={ `waypoint-${ waypoint.tocSlug }` }>
+						<a href={ `#${ waypoint.tocSlug }` }>
+							{ waypoint.tocLabel }
+						</a>
+					</li>
+				)
+			) }
+		</ul>
 	);
 }

--- a/src/frontend-global.scss
+++ b/src/frontend-global.scss
@@ -8,6 +8,7 @@
 /* Blocks and Styles */
 @import "blocks/expandable/frontend";
 @import "blocks/table-of-contents/frontend";
+@import "styles/core-columns";
 @import "styles/core-heading-report-section-heading";
 @import "styles/core-group-report-overlapping-callout";
 @import "styles/core-image";

--- a/src/styles/core-columns.scss
+++ b/src/styles/core-columns.scss
@@ -1,0 +1,18 @@
+.wp-block-columns.is-style-align-buttons-bottom {
+
+	.wp-block-column :last-child {
+		margin-bottom: 0;
+	}
+
+	@media screen and (max-width: 781px) {
+		.wp-block-column:last-child {
+			margin: 0;
+		}
+	}
+
+	@media screen and (min-width: 782px) {
+		.wp-block-column:last-child > * {
+			margin-left: auto;
+		}
+	}
+}

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -37,6 +37,7 @@
 	}
 
 	h2:not([class*="is-style-"]) {
+		margin-bottom: 2rem;
 
 		&.wp-block-heading {
 			display: inline-block;


### PR DESCRIPTION
Implemented ToC styling, and fixes display of buttons in bottom-aligned column style variant

### Desktop

[Figma Design](https://www.figma.com/file/BhUZlGRtTPSmVtPqaxuPEt/Wikimedia-Foundation-Annual-Report?node-id=2320%3A1568&mode=dev) | Preview of this PR
-------- | ----------
<img width="1011" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/b232a753-8830-4aa4-b171-9ba0671d550e"> | <img width="1051" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/cd43e3ed-6c87-4b17-8360-3158860947c6">


### Mobile 

[Figma Design](https://www.figma.com/file/BhUZlGRtTPSmVtPqaxuPEt/Wikimedia-Foundation-Annual-Report?node-id=1785%3A628&mode=dev) | Preview of this PR
-------- | ----------
<img width="417" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/ca8691dc-3f03-4498-b0b7-6fa16f48fd6f"> | <img width="352" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/cbfad122-4065-4f87-a022-0ed12f07afc0">
