### PR TITLE
Fix accordion issues

### DIFF
--- a/src/blocks/accordion-item/index.js
+++ b/src/blocks/accordion-item/index.js
@@ -24,7 +24,7 @@ registerBlockType( metadata.name, {
 	edit: Edit,
 	save: ( { attributes } ) => {
 		const blockProps = useBlockProps.save( {
-			className: 'accordion-item',
+			className: 'wmf-accordion-item',
 		} );
 		const { fontColor, title } = attributes;
 

--- a/src/features/block-accordion.js
+++ b/src/features/block-accordion.js
@@ -33,9 +33,11 @@ const addAccordionToggleHandlers = ( item ) => {
  */
 const initializeAccordionItems = () => {
 	// Hook in click events to each item.
-	[ ...document.querySelectorAll( '.wmf-accordion-item' ) ].forEach(
-		( item ) => addAccordionToggleHandlers( item )
-	);
+	[
+		...document.querySelectorAll(
+			'.wp-block-wmf-reports-accordion .wmf-accordion-item'
+		),
+	].forEach( ( item ) => addAccordionToggleHandlers( item ) );
 
 	// Open and scroll FAQ into view if visiting page with the anchor link for a section.
 	if ( document.location.hash ) {

--- a/src/features/block-accordion.js
+++ b/src/features/block-accordion.js
@@ -11,11 +11,25 @@ const toggleAccordionItem = ( e ) => {
 	e.preventDefault();
 
 	const parent = e.target.closest( '.wmf-accordion-item' );
+	const wrapper = e.target.closest( '.accordion-wrapper' );
 	const isExpanded = parent.getAttribute( 'aria-expanded' );
+
+	closeAllAccordionItems( wrapper ); // closes any opened item.
 
 	// Open items should have the empty string as the attribute value.
 	parent.toggleAttribute( 'aria-expanded', isExpanded !== '' );
 	parent.scrollIntoView( { block: 'center' } );
+};
+
+/**
+ * Closes all opened items.
+ *
+ * @param {HTMLElement} wrapper Accordion wrapper div.
+ */
+const closeAllAccordionItems = ( wrapper ) => {
+	[ ...wrapper.querySelectorAll( '.wmf-accordion-item' ) ].forEach(
+		( accordionItem ) => accordionItem.removeAttribute( 'aria-expanded' )
+	);
 };
 
 /**

--- a/src/patterns/carousel.scss
+++ b/src/patterns/carousel.scss
@@ -98,13 +98,16 @@
 }
 
 .wp-block-wmf-reports-map.carousel .carousel__buttons-wrapper {
+
 	@media only screen and ( min-width: 782px ) {
 		bottom: 2rem;
 		top: unset;
 		transform: none;
 	}
 }
+
 .wp-block-wmf-reports-stories.carousel .carousel__buttons-wrapper {
+
 	@media only screen and (max-width: 781px) {
 		top: var(--story-slide-graphic-height, 300px);
 		transform: translate(0, -50%);

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -81,6 +81,7 @@
 		margin-bottom: 2rem;
 	}
 
+	.wmf-accordion-item__title-text,
 	.accordion-item__title-text {
 		margin-bottom: 0;
 	}

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -180,6 +180,7 @@
 	.wp-block-group + figure {
 		margin-top: 3.5rem;
 	}
+
 	.wp-block-group.has-background {
 		padding-top: 3rem;
 		padding-bottom: 2rem;


### PR DESCRIPTION
My customizations of Matt's carousel caused a bug because I used the wrong classname, and we need to revert the 'leave all items open' because it is only desired on certain accordions, not all. This structure permits the behavior to have multiple drawers open, when it IS needed:

- WMF Accordion
    - WMF Accordion Item
- WMF Accordion
    - WMF Accordion Item