### PR TITLE
Accordion: Revert WEND change that broke accordion coloring

### DIFF
--- a/src/patterns/accordion.scss
+++ b/src/patterns/accordion.scss
@@ -200,7 +200,8 @@
 }
 
 .wp-block-wmf-accordion .wmf-accordion-item,
-.editor-styles-wrapper .wp-block-wmf-accordion .wmf-accordion-item {
+.editor-styles-wrapper .wp-block-wmf-accordion .wmf-accordion-item,
+.wp-block-wmf-reports-accordion--alt .wmf-accordion-item {
 
 	&[class*="vis-color"] {
 		border-left: 0;
@@ -213,18 +214,30 @@
 	}
 
 	&.vis-color-purple::before {
-		background-color: var(--wp--preset--color--vivid-purple);
+		background-color: var(--wp--preset--color--vivid-purple, #5748B5);
+	}
+
+	&.vis-color-light-purple::before {
+		background-color: #9b51df;
 	}
 
 	&.vis-color-red::before {
-		background-color: var(--wp--preset--color--wmf-report-red);
+		background-color: var(--wp--preset--color--wmf-report-red, #970302);
 	}
 
 	&.vis-color-orange::before {
-		background-color: var(--wp--preset--color--wmf-report-orange);
+		background-color: var(--wp--preset--color--wmf-report-orange, #FF7800);
+	}
+
+	&.vis-color-wend-orange {
+		background-color: #ff6801;
+	}
+
+	&.vis-color-yellow::before {
+		background-color: var(--wp--preset--color--wmf-report-yellow, #F0BC00);
 	}
 
 	&.vis-color-amber::before {
-		background-color: var(--wp--preset--color--luminous-vivid-amber);
+		background-color: var(--wp--preset--color--luminous-vivid-amber, #fcb900);
 	}
 }

--- a/src/patterns/wmf-accordion.scss
+++ b/src/patterns/wmf-accordion.scss
@@ -203,31 +203,3 @@ $primary-nav-mobile-height: 62px;
 	}
 	/* stylelint-enable no-descending-specificity */
 }
-
-/* stylelint-disable no-descending-specificity */
-.wmf-pattern-financial-statements {
-
-	.wp-block-wmf-reports-accordion--alt {
-
-		.wp-block-wmf-reports-accordion-item:nth-of-type(1) .wmf-accordion-item::before,
-		.wmf-accordion-item:nth-of-type(1)::before {
-			background-color: #9b51df;
-		}
-
-		.wp-block-wmf-reports-accordion-item:nth-of-type(2) .wmf-accordion-item::before,
-		.wmf-accordion-item:nth-of-type(2)::before {
-			background-color: #970203;
-		}
-
-		.wp-block-wmf-reports-accordion-item:nth-of-type(3) .wmf-accordion-item::before,
-		.wmf-accordion-item:nth-of-type(3)::before {
-			background-color: #ff6801;
-		}
-
-		.wp-block-wmf-reports-accordion-item:nth-of-type(4) .wmf-accordion-item::before,
-		.wmf-accordion-item:nth-of-type(4)::before {
-			background-color: #fcb900;
-		}
-	}
-}
-/* stylelint-enable no-descending-specificity */


### PR DESCRIPTION
@mattwatsoncodes Please review the following, We _will not_ be using nth-child styling for accordion coloration. We'll use utility classes added to the `WMF Accordion Item` block, available from this list here.