### PR TITLE
Copy URL to clipboard when share button is clicked

### DIFF
--- a/src/blocks/overlay/render.php
+++ b/src/blocks/overlay/render.php
@@ -7,4 +7,10 @@
 
 <template <?php echo get_block_wrapper_attributes( [ 'class' => 'alignwide' ] ); ?>>
 	<?php echo $content; ?>
+	<!-- wp:buttons -->
+	<div class="wp-block-buttons">
+	<!-- wp:button {"backgroundColor":"base100","className":"is-style-transparent is-share-button"} -->
+	<div class="wp-block-button is-style-transparent is-share-button"><a class="wp-block-button__link has-base-100-background-color has-background wp-element-button">Share This</a></div>
+	<!-- /wp:button --></div>
+	<!-- /wp:buttons -->
 </template>

--- a/src/blocks/overlay/view.js
+++ b/src/blocks/overlay/view.js
@@ -24,6 +24,10 @@ Array.from( overlays ).forEach( ( overlay ) => {
 	button.addEventListener( 'click', ( e ) => {
 		e.preventDefault();
 
+		// Update URL, in case it's not already updated.
+		const sectionId = parent.closest( '.wp-block-group[id]' )?.id;
+		location.hash = `${ sectionId }-${ parent.id }`;
+
 		const body = document.querySelector( 'body' );
 		body.style.overflow = 'hidden';
 

--- a/src/features/share-button.js
+++ b/src/features/share-button.js
@@ -1,10 +1,13 @@
 const { clipboard } = navigator;
 
-const shareButtons = document.querySelectorAll( '.is-share-button' );
-
 const clickShareButton = ( event ) => {
+	const button = event.target.closest( '.is-share-button' );
+
+	if ( ! button ) {
+		return;
+	}
+
 	const currentUrl = location.href;
-	const button = event.currentTarget;
 
 	clipboard.writeText( currentUrl ).then( () => {
 		button.classList.add( 'copied' );
@@ -12,6 +15,4 @@ const clickShareButton = ( event ) => {
 	} );
 };
 
-[ ...shareButtons ].forEach( ( button ) =>
-	button.addEventListener( 'click', clickShareButton )
-);
+document.addEventListener( 'click', clickShareButton );

--- a/src/features/share-button.js
+++ b/src/features/share-button.js
@@ -1,0 +1,18 @@
+const { clipboard } = navigator;
+
+const shareButtons = document.querySelectorAll( '.is-share-button' );
+
+const clickShareButton = ( event ) => {
+	const currentUrl = location.href;
+	const button = event.currentTarget;
+
+	clipboard.writeText( currentUrl ).then( () => {
+		button.classList.add( 'copied' );
+		setTimeout( () => button.classList.remove( 'copied' ), 5000 );
+	} );
+};
+
+[ ...shareButtons ].forEach( ( button ) =>
+	button.addEventListener( 'click', clickShareButton )
+);
+

--- a/src/features/share-button.js
+++ b/src/features/share-button.js
@@ -15,4 +15,3 @@ const clickShareButton = ( event ) => {
 [ ...shareButtons ].forEach( ( button ) =>
 	button.addEventListener( 'click', clickShareButton )
 );
-

--- a/src/frontend-global.scss
+++ b/src/frontend-global.scss
@@ -8,6 +8,7 @@
 /* Blocks and Styles */
 @import "blocks/expandable/frontend";
 @import "blocks/table-of-contents/frontend";
+@import "styles/core-buttons";
 @import "styles/core-columns";
 @import "styles/core-heading-report-section-heading";
 @import "styles/core-group-report-overlapping-callout";

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -17,3 +17,6 @@ import './features/welcome-page';
 
 // Endow accordion.
 import './features/block-accordion';
+
+// Share button click-to-copy behavior.
+import './features/share-button';

--- a/src/styles/core-buttons.scss
+++ b/src/styles/core-buttons.scss
@@ -1,0 +1,28 @@
+.wp-block-button {
+
+	&.is-share-button {
+		.wp-element-button {
+			cursor: pointer !important;
+			transition: background-color 200ms ease-in;
+			position: relative;
+			pinter-events: all;
+		}
+
+		&.copied .wp-element-button {
+
+			&:after {
+				position: absolute;
+				left: 0;
+				right: 0;
+				top: 0;
+				bottom: 0;
+				background-color: var( --wp--preset--color--wmf-report-green, #318557 ) !important;
+				color: #fff;
+				content: "Copied!";
+				display: flex;
+				align-items: center;
+				justify-content: center;
+			}
+		}
+	}
+}

--- a/src/styles/core-buttons.scss
+++ b/src/styles/core-buttons.scss
@@ -3,25 +3,28 @@
 	&.is-share-button {
 		.wp-element-button {
 			cursor: pointer !important;
-			transition: background-color 200ms ease-in;
 			position: relative;
-			pinter-events: all;
+
+			&:after {
+				opacity: 0.1;
+			}
 		}
 
 		&.copied .wp-element-button {
-
 			&:after {
-				position: absolute;
-				left: 0;
-				right: 0;
-				top: 0;
-				bottom: 0;
+				align-items: center;
 				background-color: var( --wp--preset--color--wmf-report-green, #318557 ) !important;
+				bottom: 0;
 				color: #fff;
 				content: "Copied!";
 				display: flex;
-				align-items: center;
 				justify-content: center;
+				left: 0;
+				opacity: 1;
+				position: absolute;
+				right: 0;
+				top: 0;
+				transition: all 500ms ease-in;
 			}
 		}
 	}


### PR DESCRIPTION
Provides a minimally styled share button which can be wired up by adding the class name "is-share-button" to a button.

If this class is set on the button, clicking it will copy the current URL to the user's clipboard and briefly update the button text to say "Copied!".

![image](https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/665992/932b7860-777a-4d79-b4d6-545ed90d2c2a)
