### PR TITLE
Jumplist: Position properly when admin bar not present

### DIFF
--- a/src/blocks/table-of-contents/_jumplist.scss
+++ b/src/blocks/table-of-contents/_jumplist.scss
@@ -150,9 +150,13 @@ $indicator-cutoff-width: 980px;
 		height: 2.875rem;
 		left: 0;
 		position: fixed;
-		top: 94px;
+		top: 62px;
 		width: 100%;
 		z-index: 10;
+
+		.admin-bar & {
+			top: 94px;
+		}
 
 		&__modal {
 			display: block;


### PR DESCRIPTION
Before

![admin bar issue](https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/f3423a71-db87-4865-ad1b-f7f222028b6c)

After

<img width="338" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/d470c70e-397c-403b-a383-e5d649227430">
