### PR TITLE
Visualization: Prevent datavis-accordion connector from running when not on right page.

### DIFF
--- a/src/features/datavis-interaction-2023.js
+++ b/src/features/datavis-interaction-2023.js
@@ -4,6 +4,13 @@
 window.addEventListener( 'DOMContentLoaded', () => {
 	// Only one vis this year, so that's pretty easy.
 	const visBlock = document.querySelector( '[data-datavis]' );
+	if (
+		! visBlock ||
+		! document.body.classList.contains( 'single-wmf-report' )
+	) {
+		return;
+	}
+
 	const visNodeId = visBlock.dataset.datavis;
 	const visNode = document.getElementById( visNodeId );
 


### PR DESCRIPTION
This causes a JS error on non-report pages, and should not.