### PR TITLE
Address iOS font rendering issue

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,13 +4,13 @@ Plugin Name: Wikimedia WordPress Annual Report
 Description: WP plugin to house all the functionality required for building Wikimedia's digital-first annual reports.
 Author: Human Made
 Author URI: https://hmn.md
-Version: 0.1.0
+Version: 0.1.1
 License: GPL-2.0-or-later
 */
 
 namespace WMF\Reports;
 
-const PLUGIN_VERSION = '0.1.0';
+const PLUGIN_VERSION = '0.1.1';
 
 // Expose plugin directory file system path for dirname()-free usage elsewhere.
 const PLUGIN_PATH = __DIR__;

--- a/src/helpers/variables.scss
+++ b/src/helpers/variables.scss
@@ -53,3 +53,13 @@ $line-height-base: 1.6;
 $line-height-large: 1.56;
 $line-height-xlarge: 1.43;
 $line-height-xxlarge: 2;
+
+@mixin base-font {
+	font-family: $font-family-base;
+	font-weight: 700;
+
+	@supports (-webkit-touch-callout: none) {
+		// iOS renders this font differently.
+		font-weight: 600;
+	}
+}

--- a/src/patterns/accordion.scss
+++ b/src/patterns/accordion.scss
@@ -89,8 +89,8 @@
 	}
 
 	.wmf-accordion-item__title-text {
-		font-family: $font-family-base;
-		font-weight: 700;
+
+		@include base-font;
 		font-size: #{$font-size-xlarge};
 		line-height: #{$line-height-xlarge};
 

--- a/src/patterns/by-the-numbers.scss
+++ b/src/patterns/by-the-numbers.scss
@@ -77,9 +77,17 @@
 		max-width: 330px;
 
 		&__number {
-			font-size: 88px;
+			font-size: 4.5rem;
 			font-weight: 700;
 			margin-bottom: 0;
+
+			@media screen and (min-width: 380px) {
+				font-size: 5rem;
+			}
+
+			@media screen and (min-width: 400px) {
+				font-size: 5.5rem;
+			}
 		}
 
 		&__text {

--- a/src/patterns/carousel.scss
+++ b/src/patterns/carousel.scss
@@ -218,9 +218,9 @@
 	}
 
 	&__heading {
-		font-family: $font-family-base;
+
+		@include base-font;
 		font-size: $font-size-xlarge;
-		font-weight: 700;
 	}
 
 	&__location,

--- a/src/patterns/letter-from-the-ceo.scss
+++ b/src/patterns/letter-from-the-ceo.scss
@@ -7,17 +7,7 @@
 	}
 
 	.wp-block-group figure {
-		filter: drop-shadow(0px 5px 10px rgba(0, 0, 0, 0.15));
-	}
-
-	.wp-block-group figure + p {
-		font-size: 0.9375rem;
-		line-height: 1.2;
-
-		strong {
-			display: inline-block;
-			margin-bottom: 0.5rem;
-		}
+		filter: drop-shadow(0 5px 10px rgba(0, 0, 0, 0.15));
 	}
 
 	.wp-block-quote {
@@ -27,11 +17,20 @@
 		padding-left: 0;
 
 		p {
-			font-family: $font-family-base;
+
+			@include base-font;
 			font-size: $font-size-xxlarge;
 			line-height: 1.2;
-			font-weight: 600;
 			font-style: normal;
+		}
+	}
+
+	.wp-block-group figure + p {
+		line-height: 1.2;
+
+		strong {
+			display: inline-block;
+			margin-bottom: 0.5rem;
 		}
 	}
 

--- a/src/patterns/letter-from-the-ceo.scss
+++ b/src/patterns/letter-from-the-ceo.scss
@@ -30,7 +30,7 @@
 			font-family: $font-family-base;
 			font-size: $font-size-xxlarge;
 			line-height: 1.2;
-			font-weight: 700;
+			font-weight: 600;
 			font-style: normal;
 		}
 	}

--- a/src/patterns/letter-from-the-ceo.scss
+++ b/src/patterns/letter-from-the-ceo.scss
@@ -11,6 +11,7 @@
 	}
 
 	.wp-block-group figure + p {
+		font-size: 0.9375rem;
 		line-height: 1.2;
 
 		strong {

--- a/src/patterns/welcome-page.scss
+++ b/src/patterns/welcome-page.scss
@@ -110,10 +110,10 @@
 		display: inline-block;
 		background: #000;
 		color: #fff;
-		font-family: $font-family-base;
+
+		@include base-font;
 		text-transform: uppercase;
 		font-size: 15px;
-		font-weight: 700;
 		padding: 0.5rem 1rem 0.5rem 1rem;
 		margin-bottom: 1rem;
 		position: absolute;
@@ -297,10 +297,10 @@
 		background: #000;
 		color: #fff;
 		display: inline-block;
-		font-family: $font-family-base;
+
+		@include base-font;
 		text-transform: uppercase;
 		font-size: 15px;
-		font-weight: 700;
 		padding: 0.5rem 1rem 0.5rem 1rem;
 		margin-bottom: 1rem;
 		top: 1.5rem;

--- a/src/patterns/wmf-accordion.scss
+++ b/src/patterns/wmf-accordion.scss
@@ -89,8 +89,8 @@ $primary-nav-mobile-height: 62px;
 	}
 
 	.wmf-accordion-item__title-text {
-		font-family: $font-family-base;
-		font-weight: 700;
+
+		@include base-font;
 		font-size: #{$font-size-xlarge};
 		line-height: #{$line-height-xlarge};
 

--- a/src/patterns/wrapped.scss
+++ b/src/patterns/wrapped.scss
@@ -1,4 +1,5 @@
 .wmf-pattern-wrapped {
+
 	.wp-block-buttons {
 		margin-bottom: 2.5rem;
 
@@ -6,6 +7,7 @@
 			margin-bottom: 4.25rem;
 		}
 	}
+
 	.has-medium-font-size {
 		font-size: 0.9375rem !important; // Overrides an !important rule on .has-medium-font-size.
 		margin-bottom: 1.5rem;

--- a/src/styles/endowment-overrides.scss
+++ b/src/styles/endowment-overrides.scss
@@ -23,10 +23,10 @@ body.single-wmf-report.wikimedia-endow:not(.home) {
 			display: inline-block;
 			background: #0060fe;
 			color: #fff;
-			font-family: $font-family-base;
+
+			@include base-font;
 			text-transform: uppercase;
 			font-size: 15px;
-			font-weight: 700;
 			padding: 0.5rem 1rem 0.5rem 1rem;
 			margin-bottom: 1rem;
 		}
@@ -742,10 +742,10 @@ body.single-wmf-report.wikimedia-endow:not(.home) {
 			display: inline-block;
 			background: #0060fe;
 			color: #fff;
-			font-family: $font-family-base;
+
+			@include base-font;
 			text-transform: uppercase;
 			font-size: 15px;
-			font-weight: 700;
 			padding: 4px 8px;
 			margin-bottom: 1rem;
 

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -205,9 +205,11 @@
 	}
 
 	#vg-tooltip-element table tr td {
+
 		&.key {
 			color: #444;
 		}
+
 		&.value {
 			color: #000;
 		}


### PR DESCRIPTION
<img width="187" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/9b9767c0-bbb9-40e6-934c-ce2962f5b56d">
iOS is rendering this font at a strangely bold level. Chrome treats the font as 'normal' weight at 600 and below, but iOS only bolds it to the correct degree at 600 specifically.