### PR TITLE
Keep the map height small on desktop

### DIFF
--- a/src/blocks/map/view.js
+++ b/src/blocks/map/view.js
@@ -27,10 +27,10 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const map = new mapboxgl.Map( {
 		attributionControl: false,
 		container: 'map',
-		center: [ 8.18, isWend ? 26.83 : 18.83 ],
-		minZoom: 0,
+		center: [ 8.18, isWend ? 26.83 : 9 ],
+		minZoom: -2,
 		projection: 'mercator',
-		renderWorldCopies: false,
+		renderWorldCopies: true,
 		scrollZoom: false,
 		style: mapDiv?.dataset?.mapStyle || 'mapbox://styles/mapbox/light-v11',
 		zoom: 0,

--- a/src/styles/map.scss
+++ b/src/styles/map.scss
@@ -30,7 +30,7 @@
 		width: 100%;
 
 		@media only screen and ( min-width: 782px ) {
-			height: 400px;
+			height: 250px;
 		}
 	}
 


### PR DESCRIPTION
Current
![image](https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/01910ec7-ea61-4aa1-858e-0e13dd3fe1cf)


Desired
<img width="1213" alt="image" src="https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/eb3373e9-dc62-4b33-8355-1f9c5137a8f4">
