### PR TITLE
Map: Alter map projection to configure zoom level as desired

### DIFF
--- a/src/blocks/map/view.js
+++ b/src/blocks/map/view.js
@@ -28,12 +28,11 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		attributionControl: false,
 		container: 'map',
 		center: [ 8.18, isWend ? 26.83 : 9 ],
-		minZoom: -2,
-		projection: 'mercator',
-		renderWorldCopies: true,
+		projection: 'equirectangular',
+		renderWorldCopies: false,
 		scrollZoom: false,
 		style: mapDiv?.dataset?.mapStyle || 'mapbox://styles/mapbox/light-v11',
-		zoom: 0,
+		zoom: 0.5,
 	} );
 	let mapItemIndex = 0;
 	let processingAnimation = false;


### PR DESCRIPTION
Goal: Have every map pin visible on desktop, with a minimum of vertical space usage.

- Mercator does not permit zooming out sufficiently unless renderWorldCopies is set to "true"
- Most other projections require more vertical height than Olga has requested
- Equirectangular balances the need to be able to zoom out and see white on each side with the need to maintain familiar shape outlines for continents, and allows New Zealand to be visible by default