### PR TITLE
Implement focus capture for overlay block

### DIFF
--- a/src/blocks/overlay/render.php
+++ b/src/blocks/overlay/render.php
@@ -10,7 +10,7 @@
 	<!-- wp:buttons -->
 	<div class="wp-block-buttons">
 	<!-- wp:button {"backgroundColor":"base100","className":"is-style-transparent is-share-button"} -->
-	<div class="wp-block-button is-style-transparent is-share-button"><a class="wp-block-button__link has-base-100-background-color has-background wp-element-button">Share this story</a></div>
+	<div class="wp-block-button is-style-transparent is-share-button"><a href="#" class="wp-block-button__link has-base-100-background-color has-background wp-element-button">Share this story</a></div>
 	<!-- /wp:button --></div>
 	<!-- /wp:buttons -->
 </template>


### PR DESCRIPTION
On popover trigger it will monitor the popover for the first and last focusable elements, and will capture the focus, restricting it to the popover when navigating forwards or backwards beyond these.

It also gives focus back to the trigger button when the popover is closed.