### PR TITLE
Fix two issues observed while testing

### DIFF
--- a/src/blocks/map/view.js
+++ b/src/blocks/map/view.js
@@ -76,7 +76,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 			const groupID = mapMarker.closest( '.wp-block-group[id]' )?.id;
 
-			if ( shouldScrollToElement ) {
+			if ( shouldScrollToElement && mapMarker.dataset.id ) {
 				location.hash = `${ groupID }-${ mapMarker.dataset.id }`;
 				scrollToSection( mapMarker );
 			}

--- a/src/blocks/stories/view.js
+++ b/src/blocks/stories/view.js
@@ -158,7 +158,7 @@ const setSlide = ( id, shouldScrollToElement = true ) => {
 
 		const groupID = categorySlide.closest( '.wp-block-group[id]' )?.id;
 
-		if ( shouldScrollToElement ) {
+		if ( shouldScrollToElement && categorySlide.dataset.id ) {
 			location.hash = `${ groupID }-${ categorySlide.dataset.id }`;
 			scrollToSection( categorySlide );
 		}

--- a/src/blocks/stories/view.js
+++ b/src/blocks/stories/view.js
@@ -106,6 +106,10 @@ const animateSlider = ( currentItemIndex ) => {
 };
 
 function setGraphicHeightCssProperty( slide ) {
+	if ( ! slide ) {
+		return;
+	}
+
 	// Calculate height of graphic in next story box.
 	const nextStoryGraphic =
 		slide.querySelector( 'figure iframe' ) ||


### PR DESCRIPTION
There was a situational fatal on WEND because the draft report there does not contain a stories section, and the relevant code did not guard that the element existed before running.

There is also a situation where a malformed anchor hash would be added to the document while opening a slide.