### PR TITLE
Enable zoom on cluster click

### DIFF
--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -119,6 +119,28 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 						.setDraggable( false )
 						.setLngLat( coords )
 						.addTo( map );
+
+					// On click select zoom into the cluster.
+					markerDiv.addEventListener( 'click', () => {
+						const selectedClusters = features.filter(
+							( c ) => c.id === clusterId
+						);
+
+						map.getSource( 'markers' ).getClusterExpansionZoom(
+							clusterId,
+							( err, zoom ) => {
+								if ( err ) {
+									return;
+								}
+
+								map.easeTo( {
+									center: selectedClusters[ 0 ].geometry
+										.coordinates,
+									zoom: zoom + 1,
+								} );
+							}
+						);
+					} );
 				}
 
 				// Push it to our list of existing clusters.

--- a/src/blocks/map/view.js
+++ b/src/blocks/map/view.js
@@ -266,6 +266,28 @@ document.addEventListener( 'DOMContentLoaded', () => {
 						.setDraggable( false )
 						.setLngLat( coords )
 						.addTo( map );
+
+					// On click select zoom into the cluster.
+					markerDiv.addEventListener( 'click', () => {
+						const selectedClusters = features.filter(
+							( c ) => c.id === clusterId
+						);
+
+						map.getSource( 'markers' ).getClusterExpansionZoom(
+							clusterId,
+							( err, zoom ) => {
+								if ( err ) {
+									return;
+								}
+
+								map.easeTo( {
+									center: selectedClusters[ 0 ].geometry
+										.coordinates,
+									zoom: zoom + 1,
+								} );
+							}
+						);
+					} );
 				}
 
 				// Push it to our list of existing clusters.


### PR DESCRIPTION
Adds a `click` event handler to the map clusters so that the map will zoom in and break them apart when they are clicked.

Caveat: If two pins have the exact same coordinates, this will not work, so there is some responsibility on the data configuration to ensure each pin has a unique location. 

Note about DRY: There is likely now enough map code reuse to justify separating it into it's own JavaScript object and calling its methods on the front and back end of the site, however this refactor would take time that I know we are short of. Mentioning here so that we can put this into the retainer as a ticket. 

![CleanShot 2024-04-23 at 15 45 54](https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/2066205/777d3a2c-58e8-4433-9b96-d481f4427542)
