### PR TITLE
Datavis interaction

### DIFF
--- a/src/features/block-accordion.js
+++ b/src/features/block-accordion.js
@@ -21,6 +21,7 @@ const toggleAccordionItem = ( e ) => {
 	// Open items should have the empty string as the attribute value.
 	parent.toggleAttribute( 'aria-expanded', isExpanded !== '' );
 
+	console.log( parent, parent.getBoundingClientRect() );
 	scrollToElement( parent, 400 );
 };
 

--- a/src/features/block-accordion.js
+++ b/src/features/block-accordion.js
@@ -21,7 +21,6 @@ const toggleAccordionItem = ( e ) => {
 	// Open items should have the empty string as the attribute value.
 	parent.toggleAttribute( 'aria-expanded', isExpanded !== '' );
 
-	console.log( parent, parent.getBoundingClientRect() );
 	scrollToElement( parent, 400 );
 };
 

--- a/src/features/datavis-interaction-2023.js
+++ b/src/features/datavis-interaction-2023.js
@@ -34,7 +34,12 @@ window.addEventListener( 'DOMContentLoaded', () => {
 	}
 
 	const connectEvents = ( { view, spec } ) => {
-		window.tools = { view, spec, accordionItems };
+		if ( ! view ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Could not bind to visualization' );
+			return;
+		}
+
 		view.addEventListener( 'click', ( event, item ) => {
 			if ( ! item?.datum?.className ) {
 				return;
@@ -78,12 +83,12 @@ window.addEventListener( 'DOMContentLoaded', () => {
 
 	// Poll until vis is available.
 	const pollingInterval = setInterval( () => {
-		if ( ! window.vegaLitePlugin?.visualizations ) {
+		const visualizations = window.vegaLitePlugin?.visualizations;
+		if ( ! visualizations ) {
 			return;
 		}
 
-		const visualization =
-			window.vegaLitePlugin.visualizations.get( visNodeId );
+		const visualization = visualizations.get( visNode );
 
 		if ( visualization ) {
 			// Found it! Quit poll.

--- a/src/features/datavis-interaction-2023.js
+++ b/src/features/datavis-interaction-2023.js
@@ -33,7 +33,7 @@ window.addEventListener( 'DOMContentLoaded', () => {
 		return;
 	}
 
-	const connectEvents = ( { view, spec } ) => {
+	const connectEvents = ( { view } ) => {
 		if ( ! view ) {
 			// eslint-disable-next-line no-console
 			console.error( 'Could not bind to visualization' );

--- a/src/helpers/scroll-to-element.js
+++ b/src/helpers/scroll-to-element.js
@@ -1,11 +1,28 @@
 const ADDITIONAL_MARGIN = 8; // 0.5rem, for comfort.
 
 /**
+ * Check whether an element is fully visible within the window viewport.
+ *
+ * @param {HTMLElement} element
+ * @return {bool} Whether the element is fully in-viewport.
+ */
+function isElementVisible( element ) {
+	const { top, bottom } = element.getBoundingClientRect();
+	const { innerHeight } = window;
+	return top >= 0 && bottom <= innerHeight;
+}
+
+/**
  * Variant of scrollIntoView( { block: 'start' } ) that accounts for the fixed header size.
  *
- * @param {HTMLElement} element A DOM node to scroll into view.
+ * @param {HTMLElement} element      A DOM node to scroll into view.
+ * @param {bool}        onlyIfNeeded Only perform the scroll if element is not already in view.
  */
-export default function scrollToElement( element ) {
+export default function scrollToElement( element, onlyIfNeeded ) {
+	if ( onlyIfNeeded && isElementVisible( element ) ) {
+		return;
+	}
+
 	const scrollMargin =
 		window
 			.getComputedStyle( document.body )


### PR DESCRIPTION
![vis-accordion](https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/6f4b9fa3-3b24-4d6f-9b4e-c57ec4548bda)

This PR fixes a mismatch in how we identify the visualization `view` element to make the logic for opening accordion on chart click work again.

It also adjusts the accordion anchoring to be only as-needed, so that the chart does not always scroll out of view.