### PR TITLE
Make thank-you text carousel faster and smoother

### DIFF
--- a/src/blocks/thank-you/style.scss
+++ b/src/blocks/thank-you/style.scss
@@ -4,9 +4,14 @@
  * The following styles get applied both on the frontend and editor.
  */
 
-.wp-block-wmf-reports-thank-you,
-.editor-styles-wrapper .wp-block-wmf-reports-thank-you {
-	--animation-duration: 500ms;
+.wp-block-wmf-reports-thank-you {
+	// ANIMATION STRUCTURE:
+	// We start with n different thank-you text items.
+	// When they get to the fifth-from-top position, we begin to fade them in.
+	// They fade in continually from that point.
+	// Once a line is the first child, visually transition it out of frame.
+	// Once out of frame, we move the element to the bottom (using JS).
+	--animation-duration: 1200ms;
 	--text-size: 1.75rem;
 	--height: 2.125rem;
 
@@ -21,50 +26,49 @@
 		height: var(--height);
 		letter-spacing: -0.035rem;
 		line-height: 1;
-		transition: opacity var(--animation-duration), height var(--animation-duration);
+		transition: opacity calc(3 * var(--animation-duration)) ease-in;
+		transition-delay: 200ms;
 	}
 
-	// Make all text visible when block is selected.
+	.wmf-thank-you-line:first-child {
+		opacity: 0;
+		height: 0;
+		transform: translate(0, calc(-1 * var(--height)));
+		transition:
+			opacity var(--animation-duration),
+			height var(--animation-duration) linear,
+			transform var(--animation-duration) linear;
+	}
+
+	.wmf-thank-you-line:not(:nth-child(-n+5)) {
+		opacity: 0;
+	}
+}
+
+.editor-styles-wrapper .wp-block-wmf-reports-thank-you {
+
+	.wmf-thank-you-line:nth-of-type(1) {
+		opacity: 1;
+	}
+
+	.wmf-thank-you-line:nth-of-type(2) {
+		opacity: 0.5;
+	}
+
+	.wmf-thank-you-line:nth-of-type(3) {
+		opacity: 0.2;
+	}
+
+	.wmf-thank-you-line:nth-of-type(4) {
+		opacity: 0.1;
+	}
+
+	// Make all text visible when block is selected in the editor.
 	&.is-selected {
 		height: auto;
 
 		.wmf-thank-you-line {
 			opacity: 1 !important;
 		}
-	}
-
-	// stylelint-disable no-descending-specificity
-	.wmf-thank-you-line:nth-of-type(1),
-	.wmf-thank-you-line:nth-of-type(2).fadein {
-		opacity: 1;
-	}
-
-	.wmf-thank-you-line:nth-of-type(2),
-	.wmf-thank-you-line:nth-of-type(3).fadein {
-		opacity: 0.5;
-	}
-
-	.wmf-thank-you-line:nth-of-type(3),
-	.wmf-thank-you-line:nth-of-type(4).fadein {
-		opacity: 0.2;
-	}
-
-	.wmf-thank-you-line:nth-of-type(4),
-	.wmf-thank-you-line:nth-of-type(5).fadein {
-		opacity: 0.1;
-	}
-
-	.wmf-thank-you-line:nth-of-type(5).fadein {
-		transition-duration: calc(1.5 * var(--animation-duration));
-		transition-delay: calc(0.2 * var(--animation-duration));
-	}
-
-	.wmf-thank-you-line:not(:nth-child(-n+4)),
-	.wmf-thank-you-line.fadeout {
-		opacity: 0;
-	}
-
-	.collapse {
-		height: 0;
 	}
 }

--- a/src/blocks/thank-you/view.js
+++ b/src/blocks/thank-you/view.js
@@ -2,7 +2,7 @@
  * Use this file for JavaScript code that you want to run in the front-end
  * on posts/pages that contain this block.
  */
-const ANIMATION_DURATION = 500;
+const ANIMATION_DURATION = 1200;
 
 /**
  * Pause the animation of a specific widget.
@@ -29,7 +29,7 @@ function initWidget( widget ) {
 	pauseAnimation( widget );
 	widget.dataset.thankYouAnimation = setInterval(
 		animate( widget ),
-		ANIMATION_DURATION * 4
+		ANIMATION_DURATION
 	);
 }
 
@@ -47,28 +47,7 @@ const animate = ( widget ) => () => {
 	const firstLine = lines[ 0 ];
 	const lastLine = lines[ lines.length - 1 ];
 
-	// Fade out first line.
-	firstLine.classList.add( 'fadeout' );
-	setTimeout( () => {
-		// Collapse the now-hidden first line.
-		firstLine.classList.add( 'collapse' );
-		// Fade in each subsequent line of text as the first one collapses.
-		[ 1, 2, 3, 4 ].forEach( ( indexToFadeIn ) => {
-			if ( lines[ indexToFadeIn ] ) {
-				lines[ indexToFadeIn ].classList.add( 'fadein' );
-			}
-		} );
-	}, ANIMATION_DURATION * 0.75 );
-	setTimeout( () => {
-		// Move first line down to bottom, then reset all animation classes.
-		lastLine.after( firstLine );
-		firstLine.classList.remove( 'fadeout', 'collapse' );
-		Array.from( widget.querySelectorAll( '.fadein' ) ).forEach(
-			( line ) => {
-				line.classList.remove( 'fadein' );
-			}
-		);
-	}, ANIMATION_DURATION * 1.75 );
+	lastLine.after( firstLine );
 };
 
 // Initialize!


### PR DESCRIPTION
https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/assets/442115/bd97a708-2522-4221-9c15-e16ad5c4c293

Per feedback:

> The Thank you carousel is moving rather slowly and there's a small pause every time we see the word in a new language.
>
> Please update this so that it moves more smoothly: move between each different language a bit faster and without making a pause.

Settled on 1200ms after discussion and review with @sacmp in Slack.

As an aside, I'm quite happy that this makes the code so much simpler!