### PR TITLE
Bump plugin version for asset cachebusting

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,13 +4,13 @@ Plugin Name: Wikimedia WordPress Annual Report
 Description: WP plugin to house all the functionality required for building Wikimedia's digital-first annual reports.
 Author: Human Made
 Author URI: https://hmn.md
-Version: 0.4.1
+Version: 0.5.0
 License: GPL-2.0-or-later
 */
 
 namespace WMF\Reports;
 
-const PLUGIN_VERSION = '0.4.1';
+const PLUGIN_VERSION = '0.5.0';
 
 // Expose plugin directory file system path for dirname()-free usage elsewhere.
 const PLUGIN_PATH = __DIR__;


### PR DESCRIPTION
- Version contains wikimedia/wikimedia-wordpress-annual-report-plugin#95
- Version contains wikimedia/wikimedia-wordpress-annual-report-plugin#94 and wikimedia/wikimedia-wordpress-annual-report-plugin#92 to change rewrite slug to annualreports/