### PR TITLE
Fix security policy adjustments to avoid malformed worker-src directive

### DIFF
--- a/inc/assets.php
+++ b/inc/assets.php
@@ -73,6 +73,11 @@ function allow_mapbox_csp_origins( array $allowed_origins, string $policy_type )
  * @return string[] Updated HTTP headers array.
  */
 function set_blob_worker_src_csp( array $headers ) : array {
+	preg_match( '/worker-src[^;]+blob:/', $headers['Content-Security-Policy'], $already_has_blob );
+	if ( $already_has_blob ) {
+		return $headers;
+	}
+
 	if ( strpos( $headers['Content-Security-Policy'], 'worker-src' ) !== false ) {
 		$headers['Content-Security-Policy'] = preg_replace(
 			"/worker-src /",

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -76,7 +76,7 @@ function set_blob_worker_src_csp( array $headers ) : array {
 	if ( strpos( $headers['Content-Security-Policy'], 'worker-src' ) !== false ) {
 		$headers['Content-Security-Policy'] = preg_replace(
 			"/worker-src /",
-			"worker-src blob:",
+			"worker-src blob: ",
 			$headers['Content-Security-Policy']
 		);
 	} else {


### PR DESCRIPTION
This PR makes some forward-looking adjustments in preparation for upcoming changes to the security plugin, which will allow the CSP filtering done in this plugin to be simplified.

- Fix a bug where blob: would be added incorrectly if a `worker-src` directive was already present
- Avoid mutating the CSP header string at all if it already has the necessary `worker-src blob:` directive