### PR TITLE
WIKI-1046: Use endowment-specific max width, not global WMF variable

### DIFF
--- a/src/styles/endowment-overrides.scss
+++ b/src/styles/endowment-overrides.scss
@@ -92,10 +92,10 @@ body.single-wmf-report.wikimedia-endow:not(.home) {
 	.alignwide {
 		margin-left: auto;
 		margin-right: auto;
-		max-width: variables.$width-breakpoint-wide !important;
+		max-width: $width-breakpoint-wide !important;
 		width: 100%;
 
-		@media only screen and (min-width: 1044px) and (max-width: #{variables.$width-breakpoint-wide + 64}) {
+		@media only screen and (min-width: 1044px) and (max-width: #{$width-breakpoint-wide + 64}) {
 			padding-left: 2rem;
 			padding-right: 2rem;
 		}
@@ -494,7 +494,7 @@ body.single-wmf-report.wikimedia-endow:not(.home) {
 			bottom: 12rem;
 		}
 
-		@media only screen and (min-width: variables.$width-breakpoint-wide) {
+		@media only screen and (min-width: $width-breakpoint-wide) {
 			bottom: 10rem;
 		}
 	}
@@ -515,7 +515,7 @@ body.single-wmf-report.wikimedia-endow:not(.home) {
 
 		.stories__categories-outer-wrapper.alignwide,
 		.stories__categories-wrapper.alignwide {
-			max-width: calc(variables.$width-breakpoint-wide + 4rem) !important;
+			max-width: calc($width-breakpoint-wide + 4rem) !important;
 		}
 
 		&.carousel .stories__categories-outer-wrapper.alignwide {
@@ -1022,7 +1022,7 @@ body.single-wmf-report.wikimedia-endow:not(.home) {
 				}
 			}
 
-			@media only screen and (min-width: #{ variables.$width-breakpoint-wide + 64 }) {
+			@media only screen and (min-width: #{ $width-breakpoint-wide + 64 }) {
 				margin-left: auto;
 				margin-right: auto;
 				border-bottom-right-radius: 0;
@@ -1041,7 +1041,7 @@ body.single-wmf-report.wikimedia-endow:not(.home) {
 				font-size: 0.75rem;
 				padding: 1rem 2rem;
 
-				@media only screen and (min-width: #{ variables.$width-breakpoint-wide + 64 }) {
+				@media only screen and (min-width: #{ $width-breakpoint-wide + 64 }) {
 					padding: 1rem;
 				}
 


### PR DESCRIPTION
Using the global variable caused several media queries to kick in at the wrong time, and constrained the page overall. The local version of the variable should have been left alone in #99 .

**Before**
> <img width="923" alt="image" src="https://github.com/user-attachments/assets/b4d30685-f8ad-4be6-a28f-a9b50d1a565d">


**After**
> <img width="923" alt="image" src="https://github.com/user-attachments/assets/c523df4a-a7f8-4783-849d-7f2685f9a6a5">
