### PR TITLE
Bump `actions/cache` to v4.2.2

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Cache dependencies
       id: cache-node-dependencies
-      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: node-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}-${{ inputs.cache_version }}

--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -29,7 +29,7 @@ runs:
 
     - name: Cache dependencies
       id: cache-php-dependencies
-      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: php-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('composer.lock') }}-${{ inputs.cache_version }}


### PR DESCRIPTION
4.0.1 was recently deprecated, see https://github.com/actions/cache/discussions/1510