### PR TITLE
#1066 Report image styling

### DIFF
--- a/src/styles/core-image.scss
+++ b/src/styles/core-image.scss
@@ -30,6 +30,7 @@
 	figcaption {
 		font-size: 0.75rem;
 		padding: 1rem 2rem;
+		margin-top: 0;
 
 		@media only screen and ( min-width: #{ variables.$width-breakpoint-wide + 64 } ) {
 			padding: 1rem;
@@ -82,6 +83,11 @@
 			max-width: 66.66%;
 		}
 	}
+}
+
+.wp-block-image.is-style-report-image.alignfull figcaption {
+	max-width: #{ variables.$width-breakpoint-wide + 32px };
+	margin-inline: auto;
 }
 
 // Remove padding for group wrappers around report images.

--- a/src/styles/core-image.scss
+++ b/src/styles/core-image.scss
@@ -4,7 +4,6 @@
 .wp-block-image.is-style-report-image.alignwide,
 .wp-block-image.is-style-report-image-vertical,
 .wp-block-image.is-style-report-image-vertical.alignwide {
-	background-color: #eaecf0;
 	padding-left: 0;
 	padding-right: 0;
 
@@ -83,4 +82,11 @@
 			max-width: 66.66%;
 		}
 	}
+}
+
+// Remove padding for group wrappers around report images.
+.wp-block-group.has-background:has(
+	.wp-block-image.is-style-report-image:only-child,
+	.wp-block-image.is-style-report-image-vertical:only-child ) {
+	padding: 0;
 }

--- a/src/styles/core-image.scss
+++ b/src/styles/core-image.scss
@@ -92,7 +92,7 @@
 
 // Remove padding for group wrappers around report images.
 .wp-block-group.has-background:has(
-	.wp-block-image.is-style-report-image:only-child,
-	.wp-block-image.is-style-report-image-vertical:only-child ) {
+	> .wp-block-group__inner-container > .wp-block-image.is-style-report-image:only-child,
+	> .wp-block-group__inner-container > .wp-block-image.is-style-report-image-vertical:only-child ) {
 	padding: 0;
 }

--- a/src/styles/report-2022-2023.scss
+++ b/src/styles/report-2022-2023.scss
@@ -15,6 +15,7 @@
 	.wp-block-image.is-style-report-image.alignwide,
 	.wp-block-image.is-style-report-image-vertical,
 	.wp-block-image.is-style-report-image-vertical.alignwide {
+		background-color: #eaecf0;
 
 		@media only screen and ( min-width: #{ variables.$width-breakpoint-wide + 64 } ) {
 			border-bottom-right-radius: 2rem;


### PR DESCRIPTION
Updates the report image style variant to allow colour management by wrapping in a group block, accommodate for full-width images. Border radius removed in #104 

![Screenshot 2025-03-13 at 10 46 11](https://github.com/user-attachments/assets/777cf3c8-d058-4428-9bd0-d19367d14612)

