### PR TITLE
Refactor ToC color picker component into reusable palette picker

### DIFF
--- a/src/blocks/table-of-contents/edit.js
+++ b/src/blocks/table-of-contents/edit.js
@@ -1,16 +1,13 @@
-/* eslint-disable @wordpress/no-unsafe-wp-apis */
 import { __ } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	store as blockEditorStore,
-	InspectorControls,
 	withColors,
-	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
-	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 } from '@wordpress/block-editor';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { useEffect, useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
+import PaletteColorPicker from '../../components/palette-color-picker';
 
 const noLabelMessage = __( '(Waypoint group has no ToC label)', 'wmf-reports' );
 
@@ -94,8 +91,6 @@ function Edit( {
 		} );
 	}, [ waypoints, setAttributes ] );
 
-	const colorGradientSettings = useMultipleOriginColorsAndGradients();
-
 	const customStyleProps = {};
 	if ( attributes.highlightColor ) {
 		customStyleProps[
@@ -105,25 +100,12 @@ function Edit( {
 
 	return (
 		<>
-			<InspectorControls group="color">
-				<ColorGradientSettingsDropdown
-					settings={ [
-						{
-							label: __( 'Highlight', 'wmf-reports' ),
-							colorValue:
-								highlightColor?.color ||
-								attributes.highlightColor,
-							onColorChange: ( value ) => {
-								setHighlightColor( value );
-							},
-						},
-					] }
-					panelId={ clientId }
-					hasColorsOrGradients={ false }
-					__experimentalIsRenderedInSidebar
-					{ ...colorGradientSettings }
-				/>
-			</InspectorControls>
+			<PaletteColorPicker
+				label={ __( 'Highlight', 'wmf-reports' ) }
+				color={ highlightColor?.color || attributes.highlightColor }
+				onColorChange={ setHighlightColor }
+				clientId={ clientId }
+			/>
 
 			<ul
 				{ ...useBlockProps( {

--- a/src/components/palette-color-picker/index.js
+++ b/src/components/palette-color-picker/index.js
@@ -1,0 +1,50 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
+import {
+	InspectorControls,
+	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
+	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
+} from '@wordpress/block-editor';
+
+const noop = () => {};
+
+/**
+ * Render a palette-driven color picker into a block's color settings panel,
+ * which will open a color selection popup when clicked.
+ *
+ * @param {Object}   props               React component props.
+ * @param {string}   props.color         Selected palette color value.
+ * @param {string}   props.label         Human-oriented color label.
+ * @param {Function} props.onColorChange Callback to persist a selected color.
+ * @param {string}   props.clientId      ClientID of selected block.
+ * @return {import('react').ReactNode} Rendered color picker control, within the InspectorControls slot.
+ */
+const PaletteColorPicker = ( {
+	color = null,
+	label = '',
+	onColorChange = noop,
+	clientId,
+} ) => {
+	const colorGradientSettings = useMultipleOriginColorsAndGradients();
+
+	const customColorSettings = [
+		{
+			colorValue: color,
+			onColorChange,
+			label,
+		},
+	];
+
+	return (
+		<InspectorControls group="color">
+			<ColorGradientSettingsDropdown
+				settings={ customColorSettings }
+				panelId={ clientId }
+				hasColorsOrGradients={ false }
+				__experimentalIsRenderedInSidebar
+				{ ...colorGradientSettings }
+			/>
+		</InspectorControls>
+	);
+};
+
+export default PaletteColorPicker;

--- a/src/components/palette-color-picker/readme.md
+++ b/src/components/palette-color-picker/readme.md
@@ -1,0 +1,67 @@
+# PaletteColorPicker
+
+This component abstracts the use of experimental Block Editor component APIs to render a color settings-integrated color picker into a block's style sidebar. When clicked, the sidebar control will open a panel allowing the editor to select a color from the theme's palette.
+
+If you can get by with a built-in block color supports value like text or background color, using [block supports to declare color options](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#color) is much easier than integrating a custom color into a block with this component. This component is intended for use only when the purpose of a color does not match any of those predefined block supports options. (It would not be appropriate to tell an editor that a value is going to be used for "text color" and then have it apply to something else, for example.)
+
+## Usage
+
+This component is designed to work alongside the block editor's [withColors](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#withcolors) higher-order component to enable a block color attribute to be edited.
+
+The block must first declare a color, for example `accentColor`, as one of its block attributes:
+
+```json
+{
+	"attributes": {
+		"accentColor": {
+			"type": "string"
+		}
+	}
+}
+```
+
+Then, two things have to happen with the block's `Edit` component: it must be wrapped in a `withColors()` call on export, which will inject a color object and setter for the attribute specified  by the key of the passed object.
+
+```js
+import { __ } from '@wordpress/i18n';
+import { withColors } from '@wordpress/block-editor';
+import PaletteColorPicker from '../../components/palette-color-picker';
+
+const EditBlock = ( {
+	// Normal block props:
+	clientId,
+	attributes,
+	// These come from withColors:
+	accentColor,
+	setAccentColor
+} ) => {
+	return (
+		<>
+			<PaletteColorPicker
+				label={ __( 'Accent Color', 'mytheme' ) }
+				color={ accentColor?.color || attributes.accentColor }
+				onColorChange={ setAccentColor }
+				clientId={ clientId }
+			/>
+			<div>
+				{ /* other block markup */ }
+			</div>
+		</>
+	)
+};
+
+// Tell withColors to prepare an accentColor value and setAccentColor setter,
+// based on our "accentColor" block string attribute.
+export default withColors( {
+	accentColor: 'accent-color',
+} )( Edit );
+```
+
+## Props
+
+Name | Type | Description
+---- | ---- | --------
+`color` | `string` | Selected palette color name.
+`label` | `string` | Human-oriented label for the color picker.
+`onColorChange` | `( colorName: string ) => void` | Callback to persist the selected color.
+`clientId` | `string` | Selected block's ClientID, required to properly inject the color picker into the right editor sidebar slot.

--- a/src/components/palette-color-picker/readme.md
+++ b/src/components/palette-color-picker/readme.md
@@ -27,7 +27,7 @@ import { __ } from '@wordpress/i18n';
 import { withColors } from '@wordpress/block-editor';
 import PaletteColorPicker from '../../components/palette-color-picker';
 
-const EditBlock = ( {
+const Edit = ( {
 	// Normal block props:
 	clientId,
 	attributes,


### PR DESCRIPTION
This PR extracts the color picker component from #110 and makes it reusable, hopefully useful for introducing additional color controls to other blocks.