### PR TITLE
#1065 Story section colours

### DIFF
--- a/src/blocks/expandable/block.json
+++ b/src/blocks/expandable/block.json
@@ -15,6 +15,10 @@
 		"buttonTextColor": {
 			"type": "string"
 		},
+		"fadeColor": {
+			"type": "string",
+			"default": "#fff"
+		},
 		"showMoreText": {
 			"type": "string",
 			"default": "Show more"

--- a/src/blocks/expandable/deprecated/index.js
+++ b/src/blocks/expandable/deprecated/index.js
@@ -1,0 +1,5 @@
+import v1 from './v1';
+
+const deprecated = [ v1 ];
+
+export default deprecated;

--- a/src/blocks/expandable/deprecated/v1.js
+++ b/src/blocks/expandable/deprecated/v1.js
@@ -1,0 +1,61 @@
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Added support to change colour of the fade.
+ */
+const v1 = {
+	attributes: {
+		buttonBackgroundColor: {
+			type: 'string',
+		},
+		buttonTextColor: {
+			type: 'string',
+		},
+		fadeColor: {
+			type: 'string',
+			default: '#fff',
+		},
+		showMoreText: {
+			type: 'string',
+			default: 'Show more',
+		},
+		showLessText: {
+			type: 'string',
+			default: 'Show less',
+		},
+		visibleAmount: {
+			type: 'number',
+			default: 300,
+		},
+		visibleUnit: {
+			enum: [ 'px', '%', 'vh' ],
+			default: 'px',
+		},
+	},
+	supports: {
+		html: false,
+	},
+	save: ( { attributes } ) => {
+		return (
+			<div>
+				<div
+					className="expandable-content"
+					data-visible-amount={ attributes.visibleAmount }
+					data-visible-unit={ attributes.visibleUnit }
+				>
+					<InnerBlocks.Content />
+				</div>
+				<button
+					className="expandable-expander"
+					type="button"
+					data-showmoretext={ attributes.showMoreText }
+					data-showlesstext={ attributes.showLessText }
+				>
+					{ attributes.showMoreText }
+				</button>
+			</div>
+		);
+	},
+};
+
+export default v1;

--- a/src/blocks/expandable/edit.js
+++ b/src/blocks/expandable/edit.js
@@ -16,6 +16,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+import PaletteColorPicker from '../../components/palette-color-picker';
 import useIsChildBlockSelected from '../../hooks/use-is-child-block-selected';
 
 const UNIT_OPTIONS = [
@@ -32,9 +33,18 @@ const UNIT_OPTIONS = [
  * @param {Function} props.setAttributes Function to set attributes.
  * @param {string}   props.clientId      Transient block clientId.
  * @param {bool}     props.isSelected    Whether this block is selected.
+ * @param {string}   props.fadeColor     Fade color for the block.
+ * @param {Function} props.setFadeColor  Function to set the fade color.
  * @return {React.ReactNode} Element to render.
  */
-const Edit = ( { attributes, setAttributes, clientId, isSelected } ) => {
+const Edit = ( {
+	attributes,
+	setAttributes,
+	clientId,
+	isSelected,
+	fadeColor,
+	setFadeColor,
+} ) => {
 	const blockProps = useBlockProps();
 	const isChildSelected = useIsChildBlockSelected( clientId );
 	const isExpanded =
@@ -49,6 +59,7 @@ const Edit = ( { attributes, setAttributes, clientId, isSelected } ) => {
 			'data-visible-amount': attributes.visibleAmount,
 			'data-visible-unit': attributes.visibleUnit,
 			style: {
+				'--expandable-fade-color': fadeColor?.color,
 				// Always open if child is selected or required variables are not present.
 				...( isExpanded
 					? {}
@@ -65,6 +76,12 @@ const Edit = ( { attributes, setAttributes, clientId, isSelected } ) => {
 
 	return (
 		<div { ...blockProps }>
+			<PaletteColorPicker
+				label={ __( 'Fade color', 'wmf-reports' ) }
+				color={ fadeColor?.color || attributes.fadeColor }
+				onColorChange={ setFadeColor }
+				clientId={ clientId }
+			/>
 			<InspectorControls group="styles">
 				<PanelBody intialOpen={ true }>
 					<PanelRow className="wmf-expandable-dimensions-panel">
@@ -130,4 +147,5 @@ const Edit = ( { attributes, setAttributes, clientId, isSelected } ) => {
 export default withColors( {
 	buttonBackgroundColor: 'button-bg-color',
 	buttonTextColor: 'button-text-color',
+	fadeColor: 'fade-color',
 } )( Edit );

--- a/src/blocks/expandable/frontend.scss
+++ b/src/blocks/expandable/frontend.scss
@@ -12,7 +12,11 @@
 
 	&::after {
 		bottom: 0;
-		background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 80%);
+		background: linear-gradient(
+			180deg,
+			transparent 0%,
+			var(--expandable-fade-color, #fff) 80%
+		);
 		content: "";
 		height: 2rem;
 		position: absolute;
@@ -22,6 +26,7 @@
 
 .expandable-expander {
 	background-color: #fff;
+	color: #000;
 	border: 1px solid;
 	cursor: pointer;
 	display: inline-block;

--- a/src/blocks/expandable/index.js
+++ b/src/blocks/expandable/index.js
@@ -3,6 +3,7 @@ import { createBlock, registerBlockType } from '@wordpress/blocks';
 import Edit from './edit';
 import Save from './save';
 import metadata from './block.json';
+import deprecated from './deprecated';
 
 /** @see https://www.npmjs.com/package/@wordpress/scripts#using-css */
 import './frontend.scss';
@@ -11,6 +12,7 @@ registerBlockType( metadata.name, {
 	...metadata,
 	edit: Edit,
 	save: Save,
+	deprecated,
 	transforms: {
 		from: [
 			{

--- a/src/blocks/expandable/save.js
+++ b/src/blocks/expandable/save.js
@@ -13,7 +13,12 @@ export default function Save( { attributes } ) {
 	const blockProps = useBlockProps.save();
 
 	return (
-		<div { ...blockProps }>
+		<div
+			{ ...blockProps }
+			style={ {
+				'--expandable-fade-color': `var(--wp--preset--color--${ attributes.fadeColor })`,
+			} }
+		>
 			<div
 				className="expandable-content"
 				data-visible-amount={ attributes.visibleAmount }

--- a/src/blocks/expandable/save.js
+++ b/src/blocks/expandable/save.js
@@ -3,6 +3,8 @@
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
+import { colorSlugToCSSVariable } from '../../helpers/cssVariables';
+
 /**
  * Block Save function.
  * @param {Object} props            Component Props.
@@ -16,7 +18,9 @@ export default function Save( { attributes } ) {
 		<div
 			{ ...blockProps }
 			style={ {
-				'--expandable-fade-color': `var(--wp--preset--color--${ attributes.fadeColor })`,
+				'--expandable-fade-color': colorSlugToCSSVariable(
+					attributes.fadeColor
+				),
 			} }
 		>
 			<div

--- a/src/blocks/stories/block.json
+++ b/src/blocks/stories/block.json
@@ -11,6 +11,22 @@
 		"align": {
 			"type": "string",
 			"default": "full"
+		},
+		"navTextColor": {
+			"type": "string",
+			"default": "#000000"
+		},
+		"navBackgroundColor": {
+			"type": "string",
+			"default": "#FFFFFF"
+		},
+		"navTextHoverColor": {
+			"type": "string",
+			"default": "#FFFFFF"
+		},
+		"navBackgroundHoverColor": {
+			"type": "string",
+			"default": "#FF7800"
 		}
 	},
 	"example": {},

--- a/src/blocks/stories/block.json
+++ b/src/blocks/stories/block.json
@@ -14,19 +14,19 @@
 		},
 		"navTextColor": {
 			"type": "string",
-			"default": "#000000"
+			"default": "base0"
 		},
 		"navBackgroundColor": {
 			"type": "string",
-			"default": "#FFFFFF"
+			"default": "base100"
 		},
 		"navTextHoverColor": {
 			"type": "string",
-			"default": "#FFFFFF"
+			"default": "base100"
 		},
 		"navBackgroundHoverColor": {
 			"type": "string",
-			"default": "#FF7800"
+			"default": "wmf-report-orange"
 		}
 	},
 	"example": {},

--- a/src/blocks/stories/edit.js
+++ b/src/blocks/stories/edit.js
@@ -248,6 +248,10 @@ const Edit = ( {
 										index === currentItemIndex
 											? navBackgroundHoverColor?.color
 											: navBackgroundColor?.color,
+									borderColor:
+										index === currentItemIndex
+											? navBackgroundHoverColor?.color
+											: '',
 									color:
 										index === currentItemIndex
 											? navTextHoverColor?.color

--- a/src/blocks/stories/edit.js
+++ b/src/blocks/stories/edit.js
@@ -1,8 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { RichText, useBlockProps, withColors } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
+import PaletteColorPicker from '../../components/palette-color-picker';
 
 import InnerBlocksDisplaySingle from '../../components/inner-block-slider/inner-block-single-display';
 import Navigation from '../../components/inner-block-slider/navigation';
@@ -10,16 +11,36 @@ import Navigation from '../../components/inner-block-slider/navigation';
 import './editor.scss';
 
 /**
- * The edit function describes the structure of your block in the context of the
- * editor. This represents what the editor will render when the block is used.
+ * The edit function describes the structure of your block in the context of the editor.
+ * This represents what the editor will render when the block is used.
  *
- * @param {Object} props          Block Props.
- * @param {number} props.clientId Client ID.
+ * @param {Object}   props                            Block Props.
+ * @param {number}   props.clientId                   Client ID.
+ * @param {Object}   props.attributes                 Block attributes.
+ * @param {Object}   props.navTextColor               Navigation text color.
+ * @param {Function} props.setNavTextColor            Set navigation text color.
+ * @param {Object}   props.navBackgroundColor         Navigation background color.
+ * @param {Function} props.setNavBackgroundColor      Set navigation background color.
+ * @param {Object}   props.navTextHoverColor          Navigation text hover color.
+ * @param {Function} props.setNavTextHoverColor       Set navigation text hover color.
+ * @param {Object}   props.navBackgroundHoverColor    Navigation background hover color.
+ * @param {Function} props.setNavBackgroundHoverColor Set navigation background hover color.
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
  *
  * @return {Element} Element to render.
  */
-export default function Edit( { clientId } ) {
+const Edit = ( {
+	attributes,
+	clientId,
+	navTextColor,
+	setNavTextColor,
+	navBackgroundColor,
+	setNavBackgroundColor,
+	navTextHoverColor,
+	setNavTextHoverColor,
+	navBackgroundHoverColor,
+	setNavBackgroundHoverColor,
+} ) => {
 	// Get the innerBlocks (slideBlocks).
 	const slideBlocks = useSelect(
 		( select ) =>
@@ -166,6 +187,37 @@ export default function Edit( { clientId } ) {
 
 	return (
 		<div { ...blockProps }>
+			<PaletteColorPicker
+				label={ __( 'Nav: Text', 'wmf-reports' ) }
+				color={ navTextColor?.color || attributes.navTextColor }
+				onColorChange={ setNavTextColor }
+				clientId={ clientId }
+			/>
+			<PaletteColorPicker
+				label={ __( 'Nav: Background', 'wmf-reports' ) }
+				color={
+					navBackgroundColor?.color || attributes.navBackgroundColor
+				}
+				onColorChange={ setNavBackgroundColor }
+				clientId={ clientId }
+			/>
+			<PaletteColorPicker
+				label={ __( 'Nav: Text Hover', 'wmf-reports' ) }
+				color={
+					navTextHoverColor?.color || attributes.navTextHoverColor
+				}
+				onColorChange={ setNavTextHoverColor }
+				clientId={ clientId }
+			/>
+			<PaletteColorPicker
+				label={ __( 'Nav: Background Hover', 'wmf-reports' ) }
+				color={
+					navBackgroundHoverColor?.color ||
+					attributes.navBackgroundHoverColor
+				}
+				onColorChange={ setNavBackgroundHoverColor }
+				clientId={ clientId }
+			/>
 			<div className="stories__categories-wrapper alignwide">
 				<div
 					className="stories__categories"
@@ -191,6 +243,16 @@ export default function Edit( { clientId } ) {
 									'wmf-reports'
 								) }
 								tagName="div"
+								style={ {
+									backgroundColor:
+										index === currentItemIndex
+											? navBackgroundHoverColor?.color
+											: navBackgroundColor?.color,
+									color:
+										index === currentItemIndex
+											? navTextHoverColor?.color
+											: navTextColor?.color,
+								} }
 								value={ category }
 								// eslint-disable-next-line no-shadow
 								onChange={ ( category ) => {
@@ -235,4 +297,11 @@ export default function Edit( { clientId } ) {
 			</div>
 		</div>
 	);
-}
+};
+
+export default withColors( {
+	navTextColor: 'nav-text-color',
+	navBackgroundColor: 'nav-background-color',
+	navTextHoverColor: 'nav-text-hover-color',
+	navBackgroundHoverColor: 'nav-background-hover-color',
+} )( Edit );

--- a/src/blocks/stories/render.php
+++ b/src/blocks/stories/render.php
@@ -3,6 +3,21 @@
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 
+$colors = [
+	'text' => $block->attributes['navTextColor'] ?? '',
+	'background' => $block->attributes['navBackgroundColor'] ?? '',
+	'text-hover' => $block->attributes['navTextHoverColor'] ?? '',
+	'background-hover' => $block->attributes['navBackgroundHoverColor'] ?? '',
+];
+
+$cssColors = array_map( function( $key, $value ) {
+	// if value is empty, return.
+	if ( empty( $value ) ) {
+		return;
+	}
+	return "--story-nav-$key-color: var(--wp--preset--color--$value)";
+}, array_keys( $colors ), $colors );
+
 ?>
 
 <div <?php echo get_block_wrapper_attributes( [ 'class' => 'stories carousel alignfull carousel--uninitialized' ] ); ?>>
@@ -11,6 +26,7 @@
 		<div class="stories__categories-wrapper alignwide">
 			<div
 				class="stories__categories"
+				style="<?php echo esc_attr( implode( ';', $cssColors ) ); ?>"
 			>
 			<?php
 				foreach ( $block->inner_blocks as $key => $inner_block ) {

--- a/src/blocks/stories/render.php
+++ b/src/blocks/stories/render.php
@@ -11,11 +11,14 @@ $colors = [
 ];
 
 $cssColors = array_map( function( $key, $value ) {
-	// if value is empty, return.
 	if ( empty( $value ) ) {
 		return;
 	}
-	return "--story-nav-$key-color: var(--wp--preset--color--$value)";
+
+	// If the colour ends with a number, add a hyphen before it so it matches the CSS variable name.
+	$fallback = preg_replace( '/([a-zA-Z])(\d)/', '$1-$2', $value );
+
+	return "--story-nav-$key-color: var(--wp--preset--color--$value, var(--wp--preset--color--$fallback));";
 }, array_keys( $colors ), $colors );
 
 ?>

--- a/src/blocks/stories/render.php
+++ b/src/blocks/stories/render.php
@@ -3,6 +3,8 @@
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 
+use Wmf\Reports\Utilities;
+
 $colors = [
 	'text' => $block->attributes['navTextColor'] ?? '',
 	'background' => $block->attributes['navBackgroundColor'] ?? '',
@@ -10,15 +12,14 @@ $colors = [
 	'background-hover' => $block->attributes['navBackgroundHoverColor'] ?? '',
 ];
 
-$cssColors = array_map( function( $key, $value ) {
-	if ( empty( $value ) ) {
+$cssColors = array_map( function( $context, $color_slug ) {
+	if ( empty( $color_slug ) ) {
 		return;
 	}
 
-	// If the colour ends with a number, add a hyphen before it so it matches the CSS variable name.
-	$fallback = preg_replace( '/([a-zA-Z])(\d)/', '$1-$2', $value );
+	$color = Utilities\color_slug_to_css_variable( $color_slug );
 
-	return "--story-nav-$key-color: var(--wp--preset--color--$value, var(--wp--preset--color--$fallback));";
+	return "--story-nav-$context-color:$color";
 }, array_keys( $colors ), $colors );
 
 ?>

--- a/src/blocks/stories/style.scss
+++ b/src/blocks/stories/style.scss
@@ -78,10 +78,6 @@
 			background-color: var( --story-nav-background-hover-color, #ff7800 );
 			border-color: var( --story-nav-background-hover-color, #ff7800 );
 			color: var( --story-nav-text-hover-color, #fff );
-
-			img {
-				filter: brightness(0) invert(1);
-			}
 		}
 
 		/* stylelint-disable no-descending-specificity */

--- a/src/blocks/stories/style.scss
+++ b/src/blocks/stories/style.scss
@@ -57,7 +57,8 @@
 	}
 
 	.category-slide {
-		background-color: #fff;
+		background-color: var( --story-nav-background-color, #fff );
+		color: var( --story-nav-text-color, #000 );
 		border: 1px solid #aaa;
 		cursor: pointer;
 		font-size: 0.75rem;
@@ -74,9 +75,9 @@
 		&:hover,
 		&:focus,
 		&.active {
-			background-color: #ff7800;
-			border-color: #ff7800;
-			color: #fff;
+			background-color: var( --story-nav-background-hover-color, #ff7800 );
+			border-color: var( --story-nav-background-hover-color, #ff7800 );
+			color: var( --story-nav-text-hover-color, #ffffff );
 
 			img {
 				filter: brightness(0) invert(1);

--- a/src/blocks/stories/style.scss
+++ b/src/blocks/stories/style.scss
@@ -77,7 +77,7 @@
 		&.active {
 			background-color: var( --story-nav-background-hover-color, #ff7800 );
 			border-color: var( --story-nav-background-hover-color, #ff7800 );
-			color: var( --story-nav-text-hover-color, #ffffff );
+			color: var( --story-nav-text-hover-color, #fff );
 
 			img {
 				filter: brightness(0) invert(1);

--- a/src/styles/report-2022-2023.scss
+++ b/src/styles/report-2022-2023.scss
@@ -38,4 +38,13 @@
 		}
 	}
 
+	.stories .category-slide {
+		&:hover,
+		&:focus,
+		&.active {
+			img {
+				filter: brightness(0) invert(1);
+			}
+		}
+	}
 }


### PR DESCRIPTION
- Allows the colours of the navigation section to be customisable
- Allows the fade colour of the expanded content to be customisable

Note: The 2022-2023 report inverted the colour of the icon on hover/active, since the text went from black to white. Now the colour is controlled in the editor, but there is no way to update the icon using this colour since it is an `<img>`. 