### PR TITLE
#1075 WEND Hero image 

### DIFF
--- a/src/styles/endowment-overrides.scss
+++ b/src/styles/endowment-overrides.scss
@@ -249,6 +249,40 @@ body.single-wmf-report.wikimedia-endow:not(.home) {
 			}
 		}
 
+		--tangent: 0.068;
+
+		@media only screen and (min-width: 782px) {
+			.wmf-pattern-endowment-hero__image.alignfull {
+				--corner-offset: calc( 50vw * var(--tangent) );
+				clip-path: polygon(0 0, 100% 0, 100% calc( 100% - var(--corner-offset) ), 0 100%);
+				position: relative;
+				width: 50vw;
+				max-width: initial;
+				overflow: hidden;
+				margin-bottom: calc( -1 * var(--corner-offset) );
+
+				@media only screen and (min-height: 1100px) {
+					// Prevent the image from being too tall on large screens.
+					max-height: 80vh;
+				}
+
+				img {
+					object-fit: cover;
+					width: auto;
+					height: auto;
+					min-width: 100%;
+					min-height: 100%;
+					max-width: initial;
+				}
+			}
+
+			&:has(.wmf-pattern-endowment-hero__image.alignfull) {
+				--corner-offset: calc( 100vw * var(--tangent) );
+				clip-path: polygon(0 0, 100% 0, 100% calc( 100% - var(--corner-offset) ), 0 100%);
+				overflow: hidden;
+			}
+		}
+
 		@media only screen and (max-width: 781px) {
 
 			.wp-block-column:last-child {

--- a/src/styles/endowment-overrides.scss
+++ b/src/styles/endowment-overrides.scss
@@ -273,7 +273,7 @@ body.single-wmf-report.wikimedia-endow:not(.home) {
 					height: auto;
 					min-width: 100%;
 					min-height: 100%;
-					max-width: initial;
+					max-width: 100%;
 				}
 			}
 

--- a/src/styles/endowment-overrides.scss
+++ b/src/styles/endowment-overrides.scss
@@ -249,9 +249,10 @@ body.single-wmf-report.wikimedia-endow:not(.home) {
 			}
 		}
 
-		--tangent: 0.068;
-
+		// Allow the hero image to bleed to the right of the screen using `alignfull`.
 		@media only screen and (min-width: 782px) {
+			--tangent: 0.068; // Ensures the angle of the slant is consistent.
+
 			.wmf-pattern-endowment-hero__image.alignfull {
 				--corner-offset: calc( 50vw * var(--tangent) );
 				clip-path: polygon(0 0, 100% 0, 100% calc( 100% - var(--corner-offset) ), 0 100%);
@@ -261,7 +262,7 @@ body.single-wmf-report.wikimedia-endow:not(.home) {
 				overflow: hidden;
 				margin-bottom: calc( -1 * var(--corner-offset) );
 
-				@media only screen and (min-height: 1100px) {
+				@media only screen and (min-height: 1100px) and (min-width: 1200px) {
 					// Prevent the image from being too tall on large screens.
 					max-height: 80vh;
 				}


### PR DESCRIPTION
- Adds `alignfull` support to the hero image, so it bleeds to the right side of the screen.

<img width="1512" alt="Screenshot 2025-04-07 at 23 08 25" src="https://github.com/user-attachments/assets/d5fa306c-c4a1-4940-9dc1-d242c87a375e" />
