### PR TITLE
#1084 Fix frontend colours

### DIFF
--- a/src/helpers/colors.scss
+++ b/src/helpers/colors.scss
@@ -171,3 +171,65 @@
 .has-wend-report-gold-color {
 	color: #85754e;
 }
+
+/**
+ * Fix theme colour overrides.
+ *
+ * In the Shiro theme, some colours are set to a different colour value to what
+ * is visible in the editor. This causes unexpected results when publishing.
+ * Here we are overriding those values to match the editor. This is a temporary
+ * solution and should be resolved in the theme.
+ *
+ * See:
+ * - https://github.com/wikimedia/shiro-wordpress-theme/blob/main/assets/src/sass/helpers/_style-guide-variables-overrides.scss
+ * - https://github.com/wikimedia/shiro-wordpress-theme/blob/main/inc/editor/namespace.php
+ */
+.single-wmf-report {
+	.has-bright-green-70-background-color {
+		background-color: #dbf3ec;
+	}
+
+	.has-dark-green-background-color {
+		background-color: #305d70;
+	}
+
+	.has-dark-green-70-background-color {
+		background-color: #cbd6db;
+	}
+
+	.has-green-background-color {
+		background-color: #339966;
+	}
+
+	.has-red-background-color {
+		background-color: #900;
+	}
+
+	.has-yellow-90-background-color {
+		background-color: #fef6e7;
+	}
+
+	.has-bright-green-70-color {
+		color: #dbf3ec;
+	}
+
+	.has-dark-green-color {
+		color: #305d70;
+	}
+
+	.has-dark-green-70-color {
+		color: #cbd6db;
+	}
+
+	.has-green-color {
+		color: #339966;
+	}
+
+	.has-red-color {
+		color: #900;
+	}
+
+	.has-yellow-90-color {
+		color: #fef6e7;
+	}
+}


### PR DESCRIPTION
In the Shiro theme, some colours are set to a different colour value to what is visible in the editor. This causes unexpected results when publishing. Here we are overriding those values to match the editor. This is a temporary solution and should be resolved in the theme.

See:
- https://github.com/wikimedia/shiro-wordpress-theme/blob/main/assets/src/sass/helpers/_style-guide-variables-overrides.scss
- https://github.com/wikimedia/shiro-wordpress-theme/blob/main/inc/editor/namespace.php

Differences:
<img width="632" alt="Screenshot 2025-04-08 at 11 05 39" src="https://github.com/user-attachments/assets/fe0c2e40-26d4-4a5c-8d9d-b0f36d4da90d" />

Updated colours:
<img width="383" alt="Screenshot 2025-04-08 at 11 28 16" src="https://github.com/user-attachments/assets/2bc6c411-50b8-424a-944f-823cd00ac5ec" />

<img width="351" alt="Screenshot 2025-04-08 at 11 28 34" src="https://github.com/user-attachments/assets/b5bf7555-2a3a-48b1-a487-4ee91c65a696" />

