### PR TITLE
#1051 Fix By The Numbers section alignment

### DIFF
--- a/src/patterns/by-the-numbers.scss
+++ b/src/patterns/by-the-numbers.scss
@@ -253,11 +253,6 @@
 			margin-left: auto;
 			margin-right: auto;
 		}
-
-		> .wp-block-group.alignwide {
-			padding-left: 2rem;
-			padding-right: 2rem;
-		}
 	}
 
 	.wmf-pattern-by-the-numbers__masonry {


### PR DESCRIPTION
Removes additional padding around By The Numbers section so it aligns with the rest of the content.

Before:
<img width="714" alt="Screenshot 2025-04-08 at 12 31 01" src="https://github.com/user-attachments/assets/2d1a5dfc-8df8-4a82-82c0-f26b703669c9" />


After:
<img width="696" alt="Screenshot 2025-04-08 at 12 31 18" src="https://github.com/user-attachments/assets/c8100410-f7e8-481d-91e0-64e166f66e45" />

