### PR TITLE
Allow Endowment report hero image to strech full-wide on mobile

### DIFF
--- a/src/styles/endowment-overrides.scss
+++ b/src/styles/endowment-overrides.scss
@@ -291,8 +291,10 @@ body.single-wmf-report.wikimedia-endow:not(.home) {
 			}
 
 			.wmf-pattern-endowment-hero__image {
+				max-width: 100vw;
 				margin-left: -2rem;
 				margin-right: -2rem;
+				width: 100vw;
 			}
 		}
 


### PR DESCRIPTION
Before:

![IMG_1983](https://github.com/user-attachments/assets/1d70946b-8ee4-45b8-beeb-661716fad69e)

