### PR TITLE
1112: Make map values configurable to enable variance per-usage

### DIFF
--- a/src/blocks/map/block.json
+++ b/src/blocks/map/block.json
@@ -22,6 +22,18 @@
 		"projection": {
 			"type": "string",
 			"default": "equirectangular"
+		},
+		"centerLat": {
+			"type": "number",
+			"default": 8.18
+		},
+		"centerLon": {
+			"type": "number",
+			"default": 9
+		},
+		"zoom": {
+			"type": "number",
+			"default": 0.5
 		}
 	},
 	"example": {},

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -23,8 +23,6 @@ import InnerBlocksDisplaySingle from '../../components/inner-block-slider/inner-
 import Navigation from '../../components/inner-block-slider/navigation';
 import PaletteColorPicker from '../../components/palette-color-picker';
 
-import metadata from './block.json';
-
 let map = null;
 let mapItemIndex = 0;
 
@@ -530,39 +528,28 @@ const Edit = ( {
 							},
 							{ value: 'mercator', label: 'Mercator' },
 						] }
-						value={
-							attributes.projection ||
-							metadata.attributes.projection.default
-						}
+						value={ attributes.projection }
 						onChange={ ( projection ) =>
 							setAttributes( { projection } )
 						}
 					/>
 					<NumberControl
 						label={ __( 'Center point latitude', 'wmf-reports' ) }
-						value={
-							attributes.centerLat ||
-							metadata.attributes.centerLat.default
-						}
+						value={ attributes.centerLat }
 						onChange={ ( centerLat ) =>
 							setAttributes( { centerLat: +centerLat } )
 						}
 					/>
 					<NumberControl
 						label={ __( 'Center point longitude', 'wmf-reports' ) }
-						value={
-							attributes.centerLon ||
-							metadata.attributes.centerLon.default
-						}
+						value={ attributes.centerLon }
 						onChange={ ( centerLon ) =>
 							setAttributes( { centerLon: +centerLon } )
 						}
 					/>
 					<NumberControl
 						label={ __( 'Initial zoom level', 'wmf-reports' ) }
-						value={
-							attributes.zoom || metadata.attributes.zoom.default
-						}
+						value={ attributes.zoom }
 						onChange={ ( zoom ) =>
 							setAttributes( { zoom: +zoom } )
 						}
@@ -572,15 +559,9 @@ const Edit = ( {
 			<MapPreview
 				{ ...{ mapStyle, slideBlocks, updateMarkers } }
 				projection={ attributes.projection }
-				latitude={
-					attributes.centerLat ||
-					metadata.attributes.centerLat.default
-				}
-				longitude={
-					attributes.centerLon ||
-					metadata.attributes.centerLon.default
-				}
-				zoom={ attributes.zoom || metadata.attributes.zoom.default }
+				latitude={ attributes.centerLat }
+				longitude={ attributes.centerLon }
+				zoom={ attributes.zoom }
 			/>
 			<div className="inner-block-slider">
 				<InnerBlocksDisplaySingle

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -63,6 +63,9 @@ const mapboxStyleOptions = [
  * @param {Object}   props               React component props.
  * @param {string}   props.mapStyle      mapbox:// style string URI.
  * @param {string}   props.projection    Which map projection to use.
+ * @param {number}   props.latitude      Latitude of map centerpoint.
+ * @param {number}   props.longitude     Longitude of map centerpoint.
+ * @param {number}   props.zoom          Initial zoom level of map.
  * @param {Object[]} props.slideBlocks   Block array, necessary for rerendering map.
  * @param {Function} props.updateMarkers Callback to update map pins.
  * @return {React.ReactNode} Container node for Map.

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -7,6 +7,7 @@ import {
 	withColors,
 } from '@wordpress/block-editor';
 import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl,
 	PanelBody,
 	TextControl,

--- a/src/blocks/map/render.php
+++ b/src/blocks/map/render.php
@@ -11,14 +11,19 @@ if ( ! empty( $markerActiveColor ) ) {
 	$cssColors[] = "--map-marker-active-color: var(--wp--preset--color--$markerActiveColor);";
 }
 
-$attributes = get_block_wrapper_attributes( [
+$wrapper_attributes = get_block_wrapper_attributes( [
 	'class' => 'map map--carousel carousel alignfull carousel--uninitialized',
 	'style' => implode( ';', $cssColors ),
 ] );
 ?>
 
-<div <?php echo wp_kses_data( $attributes ); ?>>
-	<div id="map" style="min-height: 250px" data-map-style="<?php echo esc_attr( $map_style ); ?>"></div>
+<div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
+	<div id="map" style="min-height: 250px"
+		data-map-style="<?php echo esc_attr( $map_style ); ?>"
+		data-latitude="<?php echo esc_attr( $attributes['centerLat'] ?? 0 ); ?>"
+		data-longitude="<?php echo esc_attr( $attributes['centerLon'] ?? 0 ); ?>"
+		data-zoom="<?php echo esc_attr( $attributes['zoom'] ?? 1 ); ?>"
+	></div>
 	<div class="carousel__carousel-wrapper">
 		<?php echo $content; ?>
 		<?php if ( substr_count( $content, 'wp-block-wmf-reports-marker' ) > 1 ) : ?>

--- a/src/blocks/map/view.js
+++ b/src/blocks/map/view.js
@@ -27,12 +27,16 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const map = new mapboxgl.Map( {
 		attributionControl: false,
 		container: 'map',
-		center: [ 8.18, isWend ? 26.83 : 9 ],
+		center: [
+			// Order is long-lat for GeoJSON parity.
+			parseFloat( mapDiv?.dataset?.longitude || 0 ),
+			parseFloat( mapDiv?.dataset?.latitude || 0 ),
+		],
 		projection: 'equirectangular',
 		renderWorldCopies: false,
 		scrollZoom: false,
 		style: mapDiv?.dataset?.mapStyle || 'mapbox://styles/mapbox/light-v11',
-		zoom: 0.5,
+		zoom: parseFloat( mapDiv?.dataset?.zoom || 1 ),
 	} );
 	let mapItemIndex = 0;
 	let processingAnimation = false;

--- a/src/blocks/map/view.js
+++ b/src/blocks/map/view.js
@@ -13,8 +13,6 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		return;
 	}
 
-	const isWend = !! document.querySelector( '.wikimedia-endow' );
-
 	mapboxgl.accessToken = wmf.apiKey;
 
 	const mapDiv = document.getElementById( 'map' );

--- a/src/blocks/stories/view.js
+++ b/src/blocks/stories/view.js
@@ -370,14 +370,16 @@ const setupCarousel = ( carousel ) => {
 	 * Check for current slide on load, and advance to it if set.
 	 */
 	document.addEventListener( 'DOMContentLoaded', () => {
-		const slideID = location.hash.slice( location.hash.lastIndexOf( '-' ) + 1 );
+		const slideID = location.hash.slice(
+			location.hash.lastIndexOf( '-' ) + 1
+		);
 		const slide = document.getElementById( slideID );
 
 		if ( slide && slide.closest( '.stories.carousel' ) ) {
 			setTimeout( () => {
-				const slideIndex = [ ...slide.parentElement.children ].findIndex(
-					( { id } ) => id === slideID
-				);
+				const slideIndex = [
+					...slide.parentElement.children,
+				].findIndex( ( { id } ) => id === slideID );
 
 				setSlide( slideIndex );
 			}, 500 );
@@ -386,4 +388,3 @@ const setupCarousel = ( carousel ) => {
 };
 
 carousels.forEach( setupCarousel );
-


### PR DESCRIPTION
We still have some hard-coded values from the 2022-2023 annual report which will complicate using the map in any other context. As a parallel to #130, this PR makes the centerpoint and initial zoom level configurable in the same manner as projection. We can deploy this to the existing sites and update the historical content as follows,

- Center: lat 9 / lon 8.18 for WMF, lat 9 / lon 26.83 for WEND
- Zoom: 0.5 for both
- Projection: equirectangular for both

and then customize as needed for future usages.