### PR TITLE
1124: UX Refresh Annual Report plugin fixes

### DIFF
--- a/inc/editor/patterns/welcome-page.php
+++ b/inc/editor/patterns/welcome-page.php
@@ -8,60 +8,10 @@ namespace WMF\Reports\Editor\Patterns\WelcomePage;
 const NAME = 'wmf-reports/welcome-page';
 
 const PATTERN = <<<CONTENT
-<!-- wp:group {"align":"full","className":"wmf-pattern-report-welcome"} -->
-<div class="wp-block-group alignfull wmf-pattern-report-welcome"><!-- wp:group {"tagName":"section","align":"full","backgroundColor":"wmf-report-blue","className":"wmf-pattern-report-into-hero is-style-default"} -->
-<section class="wp-block-group alignfull wmf-pattern-report-into-hero is-style-default has-wmf-report-blue-background-color has-background"><!-- wp:group {"align":"full","className":"wmf-pattern-report-into-hero__head"} -->
-<div class="wp-block-group alignfull wmf-pattern-report-into-hero__head"><!-- wp:image {"align":"full","id":74296,"sizeSlug":"large","linkDestination":"none","lock":{"move":false,"remove":false},"className":"wmf-pattern-report-into-hero__image"} -->
-<figure class="wp-block-image alignfull size-large wmf-pattern-report-into-hero__image"><img src="/wp-content/uploads/2024/03/PrenticeHandMural-1.jpg?w=1024" alt="The Prentice School Hand Mural" class="wp-image-74296" /></figure>
-<!-- /wp:image -->
-
-<!-- wp:group {"align":"full","className":"wmf-pattern-report-into-hero__heading-container"} -->
-<div class="wp-block-group alignfull wmf-pattern-report-into-hero__heading-container"><!-- wp:group {"templateLock":false,"lock":{"move":false,"remove":false},"align":"wide","className":"wmf-pattern-report-into-hero__heading"} -->
-<div class="wp-block-group alignwide wmf-pattern-report-into-hero__heading"><!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base90"}}}},"backgroundColor":"wmf-report-brightblue","textColor":"base90","className":"wmf-pattern-reports-hero__heading-pill"} -->
-<div class="wp-block-group wmf-pattern-reports-hero__heading-pill has-base-90-color has-wmf-report-brightblue-background-color has-text-color has-background has-link-color"><!-- wp:heading {"level":3,"className":"wmf-pattern-report-into-hero__heading-label is-style-report-section-heading has-wmf-logo"} -->
-<h3 class="wp-block-heading wmf-pattern-report-into-hero__heading-label is-style-report-section-heading has-wmf-logo"><strong>Annual Report 2022-2023</strong></h3>
-<!-- /wp:heading -->
-
-<!-- wp:heading {"level":1} -->
-<h1 class="wp-block-heading"><strong>The humans behind a year of impact around the world</strong></h1>
-<!-- /wp:heading -->
-
-<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-tertiary"} -->
-<div class="wp-block-button is-style-tertiary"><a class="wp-block-button__link wp-element-button" href="#" target="_blank" rel="noreferrer noopener">Open the latest report</a></div>
-<!-- /wp:button --></div>
-<!-- /wp:buttons --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></section>
-<!-- /wp:group -->
-
-<!-- wp:columns {"align":"wide","className":"wmf-pattern-report-intro-columns"} -->
-<div class="wp-block-columns alignwide wmf-pattern-report-intro-columns"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:heading {"level":3,"className":"is-style-h2"} -->
-<h3 class="wp-block-heading is-style-h2">All reports</h3>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>Access to all reports of Wikimedia foundation</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"width":"33%","className":"wmf-pattern-report-intro-columns__select"} -->
-<div class="wp-block-column wmf-pattern-report-intro-columns__select" style="flex-basis:33%"><!-- wp:list -->
-<ul><!-- wp:list-item -->
-<li></li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
-
-<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide","className":"wmf-pattern-previous-report-columns"} --><!-- wp:group {"align":"full","className":"wmf-pattern-report-welcome","layout":{"type":"constrained"}} -->
+<!-- wp:group {"align":"full","className":"wmf-pattern-report-welcome","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wmf-pattern-report-welcome"><!-- wp:group {"tagName":"section","align":"full","className":"wmf-pattern-report-into-hero is-style-default has-link-color","backgroundColor":"wmf-report-blue","layout":{"type":"constrained"}} -->
 <section class="wp-block-group alignfull wmf-pattern-report-into-hero is-style-default has-link-color has-wmf-report-blue-background-color has-background"><!-- wp:image {"id":77135,"sizeSlug":"large","linkDestination":"none","lock":{"move":false,"remove":false},"align":"full","className":"wmf-pattern-report-into-hero__image"} -->
-<figure class="wp-block-image alignfull size-large wmf-pattern-report-into-hero__image"><img src="/wp-content/uploads/2025/04/wiki_hero.svg" alt="" class="wp-image-77135"/></figure>
+<figure class="wp-block-image alignfull size-large wmf-pattern-report-into-hero__image"><img src="/wp-content/uploads/2025/04/wiki_hero.svg" alt="" class="wp-image-77135" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:group {"templateLock":false,"lock":{"move":false,"remove":false},"align":"wide","className":"wmf-pattern-report-into-hero__heading"} -->
@@ -112,7 +62,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":77137,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2025/04/The-internet-we-were-promised-thumbnail.png" alt="" class="wp-image-77137" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2025/04/The-internet-we-were-promised-thumbnail.png" alt="" class="wp-image-77137" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -132,7 +82,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74600,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/PrenticeHandMural_2f0333.jpg" alt="" class="wp-image-74600" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/PrenticeHandMural_2f0333.jpg" alt="" class="wp-image-74600" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -152,7 +102,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74601,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/WikiCon_Brasil_2022_-_Fotografia_em_grupo_24.jpg" alt="" class="wp-image-74601" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/WikiCon_Brasil_2022_-_Fotografia_em_grupo_24.jpg" alt="" class="wp-image-74601" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -174,7 +124,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":66777,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2022/04/annualreport-cover.jpg" alt="" class="wp-image-66777" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2022/04/annualreport-cover.jpg" alt="" class="wp-image-66777" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -194,7 +144,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74602,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/wiki-w-2020-new.jpg" alt="" class="wp-image-74602" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/wiki-w-2020-new.jpg" alt="" class="wp-image-74602" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -214,7 +164,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74603,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Wikimedians-world.jpg" alt="" class="wp-image-74603" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Wikimedians-world.jpg" alt="" class="wp-image-74603" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -236,7 +186,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74604,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Jamie_Tubers_at_Wikimedia_Conference_2018.jpg" alt="" class="wp-image-74604" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Jamie_Tubers_at_Wikimedia_Conference_2018.jpg" alt="" class="wp-image-74604" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -256,7 +206,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74605,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/ISS-52_Aurora_australis_above_Antarctica.jpg" alt="" class="wp-image-74605" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/ISS-52_Aurora_australis_above_Antarctica.jpg" alt="" class="wp-image-74605" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -276,7 +226,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74606,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Wikimedia_Foundation_Annual_Report_2016_books.jpg" alt="" class="wp-image-74606" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Wikimedia_Foundation_Annual_Report_2016_books.jpg" alt="" class="wp-image-74606" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -298,7 +248,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74607,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Young_girls_reading_-_Government_primary_school_in_Amman_Jordan.jpg" alt="" class="wp-image-74607" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Young_girls_reading_-_Government_primary_school_in_Amman_Jordan.jpg" alt="" class="wp-image-74607" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -318,7 +268,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74608,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Sinenjongo_graduation_matric_2013-10-12_0381.jpg" alt="" class="wp-image-74608" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Sinenjongo_graduation_matric_2013-10-12_0381.jpg" alt="" class="wp-image-74608" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -338,7 +288,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74609,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Wmf-AR12_cover2_300dpi.png" alt="" class="wp-image-74609" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Wmf-AR12_cover2_300dpi.png" alt="" class="wp-image-74609" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -360,7 +310,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74611,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/WMF_Annual_Report_2011–12_EN_cover_rgb_300ppi.png" alt="" class="wp-image-74611" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/WMF_Annual_Report_2011–12_EN_cover_rgb_300ppi.png" alt="" class="wp-image-74611" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -380,7 +330,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74612,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Page1-250px-WMF_AR11_SHIP_spreads_15dec11_72dpi.png" alt="" class="wp-image-74612" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Page1-250px-WMF_AR11_SHIP_spreads_15dec11_72dpi.png" alt="" class="wp-image-74612" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -400,7 +350,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74613,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/WMF_Annual_Report_2009_2010_Cover_image.png" alt="" class="wp-image-74613" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/WMF_Annual_Report_2009_2010_Cover_image.png" alt="" class="wp-image-74613" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -422,7 +372,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74614,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Thumbnail20082009WMFAR.jpg" alt="" class="wp-image-74614" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Thumbnail20082009WMFAR.jpg" alt="" class="wp-image-74614" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -442,7 +392,7 @@ const PATTERN = <<<CONTENT
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"id":74615,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Wikimedia_Foundation_Annual_Report_2007-2008_cover.jpg" alt="" class="wp-image-74615" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Wikimedia_Foundation_Annual_Report_2007-2008_cover.jpg" alt="" class="wp-image-74615" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -465,7 +415,7 @@ const PATTERN = <<<CONTENT
 <div class="wp-block-group alignfull wmf-pattern-report-intro-donate has-red-90-background-color has-background"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:image {"id":282,"aspectRatio":"4/3","scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="/wp-content/uploads/2018/06/ArtAndFeminism_2017_Livrustkammaren_06-e1533254907593.jpg?w=1024" alt="Wikipedia edit-a-thon Art+Feminism at the Royal Armoury in Stockholm" class="wp-image-282" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<figure class="wp-block-image size-large"><img src="/wp-content/uploads/2018/06/ArtAndFeminism_2017_Livrustkammaren_06-e1533254907593.jpg?w=1024" alt="Wikipedia edit-a-thon Art+Feminism at the Royal Armoury in Stockholm" class="wp-image-282" style="aspect-ratio:4/3;object-fit:cover" /></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 

--- a/inc/editor/patterns/welcome-page.php
+++ b/inc/editor/patterns/welcome-page.php
@@ -12,7 +12,7 @@ const PATTERN = <<<CONTENT
 <div class="wp-block-group alignfull wmf-pattern-report-welcome"><!-- wp:group {"tagName":"section","align":"full","backgroundColor":"wmf-report-blue","className":"wmf-pattern-report-into-hero is-style-default"} -->
 <section class="wp-block-group alignfull wmf-pattern-report-into-hero is-style-default has-wmf-report-blue-background-color has-background"><!-- wp:group {"align":"full","className":"wmf-pattern-report-into-hero__head"} -->
 <div class="wp-block-group alignfull wmf-pattern-report-into-hero__head"><!-- wp:image {"align":"full","id":74296,"sizeSlug":"large","linkDestination":"none","lock":{"move":false,"remove":false},"className":"wmf-pattern-report-into-hero__image"} -->
-<figure class="wp-block-image alignfull size-large wmf-pattern-report-into-hero__image"><img src="https://wikimediafoundation-org-develop.go-vip.co/wp-content/uploads/2024/03/PrenticeHandMural-1.jpg?w=1024" alt="The Prentice School Hand Mural" class="wp-image-74296" /></figure>
+<figure class="wp-block-image alignfull size-large wmf-pattern-report-into-hero__image"><img src="/wp-content/uploads/2024/03/PrenticeHandMural-1.jpg?w=1024" alt="The Prentice School Hand Mural" class="wp-image-74296" /></figure>
 <!-- /wp:image -->
 
 <!-- wp:group {"align":"full","className":"wmf-pattern-report-into-hero__heading-container"} -->
@@ -58,19 +58,85 @@ const PATTERN = <<<CONTENT
 <!-- /wp:columns -->
 
 <!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide","className":"wmf-pattern-previous-report-columns"} --><!-- wp:group {"align":"full","className":"wmf-pattern-report-welcome","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull wmf-pattern-report-welcome"><!-- wp:group {"tagName":"section","align":"full","className":"wmf-pattern-report-into-hero is-style-default has-link-color","backgroundColor":"wmf-report-blue","layout":{"type":"constrained"}} -->
+<section class="wp-block-group alignfull wmf-pattern-report-into-hero is-style-default has-link-color has-wmf-report-blue-background-color has-background"><!-- wp:image {"id":77135,"sizeSlug":"large","linkDestination":"none","lock":{"move":false,"remove":false},"align":"full","className":"wmf-pattern-report-into-hero__image"} -->
+<figure class="wp-block-image alignfull size-large wmf-pattern-report-into-hero__image"><img src="/wp-content/uploads/2025/04/wiki_hero.svg" alt="" class="wp-image-77135"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:group {"templateLock":false,"lock":{"move":false,"remove":false},"align":"wide","className":"wmf-pattern-report-into-hero__heading"} -->
+<div class="wp-block-group alignwide wmf-pattern-report-into-hero__heading"><!-- wp:group {"className":"wmf-pattern-reports-hero__heading-pill has-link-color","style":{"elements":{"link":{"color":{"text":"var:preset|color|base90"}}}},"backgroundColor":"wmf-report-bright-green","textColor":"base90"} -->
+<div class="wp-block-group wmf-pattern-reports-hero__heading-pill has-link-color has-base-90-color has-wmf-report-bright-green-background-color has-text-color has-background"><!-- wp:heading {"level":3,"className":"wmf-pattern-report-into-hero__heading-label is-style-report-section-heading has-wmf-logo"} -->
+<h3 class="wp-block-heading wmf-pattern-report-into-hero__heading-label is-style-report-section-heading has-wmf-logo"><strong>Annual Report 2023-2024</strong></h3>
+<!-- /wp:heading -->
+
+<!-- wp:heading {"level":1} -->
+<h1 class="wp-block-heading"><strong>The internet we were promised</strong></h1>
+<!-- /wp:heading -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"base","className":"is-style-transparent","fontSize":"small"} -->
+<div class="wp-block-button is-style-transparent"><a class="wp-block-button__link has-base-background-color has-background has-small-font-size has-custom-font-size wp-element-button" href="/annualreports/2023-2024-annual-report/">Open the latest report</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></section>
+<!-- /wp:group -->
+
+<!-- wp:columns {"align":"wide","className":"wmf-pattern-report-intro-columns"} -->
+<div class="wp-block-columns alignwide wmf-pattern-report-intro-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:heading {"level":3,"className":"is-style-h2"} -->
+<h3 class="wp-block-heading is-style-h2">All reports</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Access to all reports of the Wikimedia Foundation</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"33%","className":"wmf-pattern-report-intro-columns__select"} -->
+<div class="wp-block-column wmf-pattern-report-intro-columns__select" style="flex-basis:33%"><!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide","className":"wmf-pattern-previous-report-columns"} -->
 <div class="wp-block-columns alignwide wmf-pattern-previous-report-columns"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
 <div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
-<p class="wmf-pattern-previous-report__duration">2022-2023</p>
+<p class="wmf-pattern-previous-report__duration"><strong>2023-2024</strong></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"id":74197,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- wp:image {"id":77137,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2025/04/The-internet-we-were-promised-thumbnail.png" alt="" class="wp-image-77137" style="aspect-ratio:4/3;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
-<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="#"><strong>The people behind a year of impact around the world </strong></a></h4>
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><strong><a href="/annualreports/2023-2024-annual-report/" target="_blank" rel="noreferrer noopener">The internet we were promised</a></strong></h4>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
+<p class="wmf-pattern-previous-report__date">July 1, 2023 to June 30, 2024</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
+<div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
+<p class="wmf-pattern-previous-report__duration"><strong>2022-2023</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":74600,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/PrenticeHandMural_2f0333.jpg" alt="" class="wp-image-74600" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><strong><a href="/about/annualreport/2022-2023-annual-report/" target="_blank" rel="noreferrer noopener">The humans behind a year of impact around the world</a></strong></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
@@ -82,39 +148,19 @@ const PATTERN = <<<CONTENT
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
 <div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
-<p class="wmf-pattern-previous-report__duration">2022-2023</p>
+<p class="wmf-pattern-previous-report__duration"><strong>2021-2022</strong></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"id":74197,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- wp:image {"id":74601,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/WikiCon_Brasil_2022_-_Fotografia_em_grupo_24.jpg" alt="" class="wp-image-74601" style="aspect-ratio:4/3;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
-<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="#"><strong>The people behind a year of impact around the world </strong></a></h4>
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="/about/annualreport/2022-annual-report/" target="_blank" rel="noreferrer noopener"><strong>Pillars that inspire </strong></a></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
-<p class="wmf-pattern-previous-report__date">July 1, 2022 to June 30, 2023</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group --></div>
-<!-- /wp:column -->
-
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
-<div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
-<p class="wmf-pattern-previous-report__duration">2022-2023</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:image {"id":74197,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="aspect-ratio:4/3;object-fit:cover"/></figure>
-<!-- /wp:image -->
-
-<!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
-<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="#"><strong>The people behind a year of impact around the world </strong></a></h4>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
-<p class="wmf-pattern-previous-report__date">July 1, 2022 to June 30, 2023</p>
+<p class="wmf-pattern-previous-report__date">July 1, 2021 to June 30, 2022</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
@@ -124,19 +170,19 @@ const PATTERN = <<<CONTENT
 <div class="wp-block-columns alignwide wmf-pattern-previous-report-columns"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
 <div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
-<p class="wmf-pattern-previous-report__duration">2022-2023</p>
+<p class="wmf-pattern-previous-report__duration"><strong>2020-2021</strong></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"id":74197,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- wp:image {"id":66777,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2022/04/annualreport-cover.jpg" alt="" class="wp-image-66777" style="aspect-ratio:4/3;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
-<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="#"><strong>The people behind a year of impact around the world </strong></a></h4>
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="/about/annualreport/2021-annual-report/" target="_blank" rel="noreferrer noopener"><strong>The people behind a year of impact around the world </strong></a></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
-<p class="wmf-pattern-previous-report__date">July 1, 2022 to June 30, 2023</p>
+<p class="wmf-pattern-previous-report__date">July 1, 2020 to June 30, 2021</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
@@ -144,19 +190,19 @@ const PATTERN = <<<CONTENT
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
 <div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
-<p class="wmf-pattern-previous-report__duration">2022-2023</p>
+<p class="wmf-pattern-previous-report__duration"><strong>2019-2020</strong></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"id":74197,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- wp:image {"id":74602,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/wiki-w-2020-new.jpg" alt="" class="wp-image-74602" style="aspect-ratio:4/3;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
-<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="#"><strong>The people behind a year of impact around the world </strong></a></h4>
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><strong><a href="/about/annualreport/2020-annual-report/" target="_blank" rel="noreferrer noopener">20 years of Wikipedia</a> </strong></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
-<p class="wmf-pattern-previous-report__date">July 1, 2022 to June 30, 2023</p>
+<p class="wmf-pattern-previous-report__date">July 1, 2019 to June 30, 2020</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
@@ -164,19 +210,19 @@ const PATTERN = <<<CONTENT
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
 <div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
-<p class="wmf-pattern-previous-report__duration">2022-2023</p>
+<p class="wmf-pattern-previous-report__duration"><strong>2018-2019</strong></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"id":74197,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- wp:image {"id":74603,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Wikimedians-world.jpg" alt="" class="wp-image-74603" style="aspect-ratio:4/3;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
-<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="#"><strong>The people behind a year of impact around the world </strong></a></h4>
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="/about/annualreport/2019-annual-report/" target="_blank" rel="noreferrer noopener"><strong>The people behind a year of impact around the world </strong></a></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
-<p class="wmf-pattern-previous-report__date">July 1, 2022 to June 30, 2023</p>
+<p class="wmf-pattern-previous-report__date">July 1, 2018 to June 30, 2019</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
@@ -186,19 +232,19 @@ const PATTERN = <<<CONTENT
 <div class="wp-block-columns alignwide wmf-pattern-previous-report-columns"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
 <div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
-<p class="wmf-pattern-previous-report__duration">2022-2023</p>
+<p class="wmf-pattern-previous-report__duration"><strong>2017-2018</strong></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"id":74197,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- wp:image {"id":74604,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Jamie_Tubers_at_Wikimedia_Conference_2018.jpg" alt="" class="wp-image-74604" style="aspect-ratio:4/3;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
-<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="#"><strong>The people behind a year of impact around the world </strong></a></h4>
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="/about/2018-annual-report/" target="_blank" rel="noreferrer noopener"><strong>Knowledge is progress </strong></a></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
-<p class="wmf-pattern-previous-report__date">July 1, 2022 to June 30, 2023</p>
+<p class="wmf-pattern-previous-report__date">July 1, 2017 to June 30, 2018</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
@@ -206,19 +252,19 @@ const PATTERN = <<<CONTENT
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
 <div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
-<p class="wmf-pattern-previous-report__duration">2022-2023</p>
+<p class="wmf-pattern-previous-report__duration"><strong>2016-2017</strong></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"id":74197,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- wp:image {"id":74605,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/ISS-52_Aurora_australis_above_Antarctica.jpg" alt="" class="wp-image-74605" style="aspect-ratio:4/3;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
-<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="#"><strong>The people behind a year of impact around the world </strong></a></h4>
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><strong><a href="https://annual.wikimedia.org/2017/" target="_blank" rel="noreferrer noopener">Knowledge belongs to all of us </a>  </strong></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
-<p class="wmf-pattern-previous-report__date">July 1, 2022 to June 30, 2023</p>
+<p class="wmf-pattern-previous-report__date">July 1, 2016 to June 30, 2017</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->
@@ -226,11 +272,157 @@ const PATTERN = <<<CONTENT
 <!-- wp:column -->
 <div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
 <div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
-<p class="wmf-pattern-previous-report__duration">2022-2023</p>
+<p class="wmf-pattern-previous-report__duration"><strong>2015-2016</strong></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:image {"id":74197,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
-<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png" alt="" class="wp-image-74197" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- wp:image {"id":74606,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Wikimedia_Foundation_Annual_Report_2016_books.jpg" alt="" class="wp-image-74606" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="https://annual.wikimedia.org/2016/" target="_blank" rel="noreferrer noopener"><strong>Facts matter </strong></a></h4>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
+<p class="wmf-pattern-previous-report__date">July 1, 2015 to June 30, 2016</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns {"align":"wide","className":"wmf-pattern-previous-report-columns"} -->
+<div class="wp-block-columns alignwide wmf-pattern-previous-report-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
+<div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
+<p class="wmf-pattern-previous-report__duration"><strong>2014-2015</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":74607,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Young_girls_reading_-_Government_primary_school_in_Amman_Jordan.jpg" alt="" class="wp-image-74607" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="https://annual.wikimedia.org/2015/" target="_blank" rel="noreferrer noopener"><strong>Knowledge is joy </strong></a></h4>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
+<p class="wmf-pattern-previous-report__date">July 1, 2014 to June 30, 2015</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
+<div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
+<p class="wmf-pattern-previous-report__duration"><strong>2013-2014</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":74608,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Sinenjongo_graduation_matric_2013-10-12_0381.jpg" alt="" class="wp-image-74608" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="https://annual.wikimedia.org/2014/" target="_blank" rel="noreferrer noopener"><strong>Knowledge is a foundation </strong></a></h4>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
+<p class="wmf-pattern-previous-report__date">July 1, 2013 to June 30, 2014</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
+<div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
+<p class="wmf-pattern-previous-report__duration"><strong>2012-2013</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":74609,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Wmf-AR12_cover2_300dpi.png" alt="" class="wp-image-74609" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="https://meta.wikimedia.org/wiki/Wikimedia_Foundation/Annual_Report/2012-13" target="_blank" rel="noreferrer noopener"><strong>Ten years of sharing and learning </strong></a></h4>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
+<p class="wmf-pattern-previous-report__date">July 1, 2012 to June 30, 2013</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns {"align":"wide","className":"wmf-pattern-previous-report-columns"} -->
+<div class="wp-block-columns alignwide wmf-pattern-previous-report-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
+<div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
+<p class="wmf-pattern-previous-report__duration"><strong>2011-2012</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":74611,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/WMF_Annual_Report_2011–12_EN_cover_rgb_300ppi.png" alt="" class="wp-image-74611" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="https://meta.wikimedia.org/wiki/Wikimedia_Foundation/Annual_Report/2011-12" target="_blank" rel="noreferrer noopener"><strong>The voice of the world </strong></a></h4>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
+<p class="wmf-pattern-previous-report__date">July 1, 2011 to June 30, 2012</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
+<div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
+<p class="wmf-pattern-previous-report__duration"><strong>2010-2011</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":74612,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Page1-250px-WMF_AR11_SHIP_spreads_15dec11_72dpi.png" alt="" class="wp-image-74612" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="https://meta.wikimedia.org/wiki/Wikimedia_Foundation/Annual_Report/2010-11" target="_blank" rel="noreferrer noopener"><strong>The way the world tells its story </strong></a></h4>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
+<p class="wmf-pattern-previous-report__date">July 1, 2010 to June 30, 2011</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
+<div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
+<p class="wmf-pattern-previous-report__duration"><strong>2009-2010</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":74613,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/WMF_Annual_Report_2009_2010_Cover_image.png" alt="" class="wp-image-74613" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="https://upload.wikimedia.org/wikipedia/commons/9/9f/AR_web_all-spreads_24mar11_72_FINAL.pdf"><strong>Imagine a world in which... </strong></a></h4>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
+<p class="wmf-pattern-previous-report__date">July 1, 2009 to June 30, 2010</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns {"align":"wide","className":"wmf-pattern-previous-report-columns"} -->
+<div class="wp-block-columns alignwide wmf-pattern-previous-report-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
+<div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
+<p class="wmf-pattern-previous-report__duration"><strong>2008-2009</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":74614,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Thumbnail20082009WMFAR.jpg" alt="" class="wp-image-74614" style="aspect-ratio:4/3;object-fit:cover"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
@@ -238,18 +430,42 @@ const PATTERN = <<<CONTENT
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
-<p class="wmf-pattern-previous-report__date">July 1, 2022 to June 30, 2023</p>
+<p class="wmf-pattern-previous-report__date">July 1, 2008 to June 30, 2009</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"className":"wmf-pattern-previous-report"} -->
+<div class="wp-block-group wmf-pattern-previous-report"><!-- wp:paragraph {"className":"wmf-pattern-previous-report__duration"} -->
+<p class="wmf-pattern-previous-report__duration"><strong>2007-2008</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":74615,"aspectRatio":"4/3","scale":"cover","sizeSlug":"full","linkDestination":"none","className":"wmf-pattern-previous-report__image"} -->
+<figure class="wp-block-image size-full wmf-pattern-previous-report__image"><img src="/wp-content/uploads/2024/04/Wikimedia_Foundation_Annual_Report_2007-2008_cover.jpg" alt="" class="wp-image-74615" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading {"level":4,"className":"wmf-pattern-previous-report__link"} -->
+<h4 class="wp-block-heading wmf-pattern-previous-report__link"><a href="https://upload.wikimedia.org/wikipedia/commons/2/26/WMF_20072008_Annual_report._high_resolution.pdf" target="_blank" rel="noreferrer noopener"><strong>Wikimedia Foundation Annual Report </strong></a></h4>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"wmf-pattern-previous-report__date"} -->
+<p class="wmf-pattern-previous-report__date">July 1, 2007 to June 30, 2008</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","backgroundColor":"red90","className":"wmf-pattern-report-intro-donate"} -->
+<!-- wp:group {"align":"full","className":"wmf-pattern-report-intro-donate","backgroundColor":"red90","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wmf-pattern-report-intro-donate has-red-90-background-color has-background"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:image {"id":74197,"aspectRatio":"4/3","scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wikimedia.vipdev.lndo.site/wp-content/uploads/2024/01/Wikimedia_Foundation_AI_Blog_Series_Header.png?w=980" alt="" class="wp-image-74197" style="aspect-ratio:4/3;object-fit:cover"/></figure>
+<div class="wp-block-column"><!-- wp:image {"id":282,"aspectRatio":"4/3","scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="/wp-content/uploads/2018/06/ArtAndFeminism_2017_Livrustkammaren_06-e1533254907593.jpg?w=1024" alt="Wikipedia edit-a-thon Art+Feminism at the Royal Armoury in Stockholm" class="wp-image-282" style="aspect-ratio:4/3;object-fit:cover"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
@@ -274,27 +490,5 @@ const PATTERN = <<<CONTENT
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:group --></div>
-<!-- /wp:group -->
-
-<!-- wp:group {"align":"wide","className":"wmf-pattern-report-intro-contact","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide wmf-pattern-report-intro-contact"><!-- wp:shiro/contact -->
-<div class="wp-block-shiro-contact contact"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="none" viewBox="0 0 24 24" class="contact__icon"><path fill="#000" fill-rule="evenodd" d="M14.5 5.5a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0M2 16c0-2 2.083-5 8-5s8 3 8 5v3H2z" clip-rule="evenodd"></path></svg><h3 class="contact__title">Contact a human</h3><div class="contact__description">Questions about the Wikimedia Foundation or our projects? Get in touch with our team.</div><h4 class="contact__social-title">Follow</h4><!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-as-link has-icon has-icon-social-facebook-blue"} -->
-<div class="wp-block-button is-style-as-link has-icon has-icon-social-facebook-blue"><a class="wp-block-button__link wp-element-button" href="https://www.facebook.com/wikimediafoundation/" target="_blank" rel="noreferrer noopener">Facebook</a></div>
-<!-- /wp:button -->
-
-<!-- wp:button {"className":"is-style-as-link has-icon has-icon-social-twitter-blue"} -->
-<div class="wp-block-button is-style-as-link has-icon has-icon-social-twitter-blue"><a class="wp-block-button__link wp-element-button" href="https://twitter.com/wikimedia" target="_blank" rel="noreferrer noopener">Twitter</a></div>
-<!-- /wp:button -->
-
-<!-- wp:button {"className":"is-style-as-link has-icon has-icon-social-instagram-blue"} -->
-<div class="wp-block-button is-style-as-link has-icon has-icon-social-instagram-blue"><a class="wp-block-button__link wp-element-button" href="https://www.instagram.com/wikimediafoundation/" target="_blank" rel="noreferrer noopener">Instagram</a></div>
-<!-- /wp:button -->
-
-<!-- wp:button {"className":"is-style-as-link has-icon has-icon-social-linkedin-blue"} -->
-<div class="wp-block-button is-style-as-link has-icon has-icon-social-linkedin-blue"><a class="wp-block-button__link wp-element-button" href="https://www.linkedin.com/company/wikimedia-foundation" target="_blank" rel="noreferrer noopener">LinkedIn</a></div>
-<!-- /wp:button --></div>
-<!-- /wp:buttons --></div>
-<!-- /wp:shiro/contact --></div>
 <!-- /wp:group -->
 CONTENT;

--- a/src/patterns/hero.scss
+++ b/src/patterns/hero.scss
@@ -4,12 +4,25 @@
 	padding: 0 !important;
 	margin-bottom: 3rem !important;
 
-	.wp-block-group__inner-container {
-		position: relative;
+	&__head {
+		display: grid;
+		overflow: hidden;
+	}
+
+	.wp-block-wmf-reports-animation {
+		aspect-ratio: initial !important;
+	}
+
+	.wp-block-wmf-reports-animation,
+	&__heading-container {
+		grid-column: 1 / span 1;
+		grid-row: 1 / span 1;
+	}
+
+	&__heading-container {
 	}
 
 	&__heading-label {
-
 		img {
 			filter: brightness(0) invert(1);
 			line-height: 0;
@@ -18,30 +31,12 @@
 		}
 	}
 
-	&__heading-container {
-		transform: translateY(-50%);
-		margin-bottom: calc(-0.5 * var(--report-overlapping-callout-group-block-height, 200px));
-
-		@media only screen and ( min-width: 782px ) {
-			margin-bottom: 0;
-			position: absolute;
-			top: 50%;
-		}
-	}
-
-	&__heading.alignwide {
-		margin-left: -2rem !important;
-
-		@media only screen and ( min-width: 782px ) {
-			margin-left: auto !important;
-		}
-	}
-
 	&__heading-pill.wp-block-group.has-background {
 		border-radius: 0 30px 30px 0;
 		max-width: 34rem;
-		width: 90vw;
 		padding: 2rem;
+		position: relative;
+		width: 90vw;
 
 		.editor-styles-wrapper & {
 			width: 90%;
@@ -50,7 +45,7 @@
 		h1 {
 			font-size: 2.1875rem;
 			line-height: 1.3;
-			margin-bottom: 0;
+			margin-top: 0;
 		}
 
 		h2.is-style-report-section-heading {
@@ -59,7 +54,7 @@
 			transform: translate(0, -50%);
 		}
 
-		@media only screen and ( min-width: 782px ) {
+		@media only screen and (min-width: 782px) {
 			border-radius: 30px;
 
 			h2.is-style-report-section-heading {
@@ -83,8 +78,7 @@
 	}
 
 	.wmf-animation {
-
-		@media only screen and ( max-width: 781px ) {
+		@media only screen and (max-width: 781px) {
 			overflow: hidden;
 			aspect-ratio: 2 / 1 !important;
 
@@ -93,7 +87,7 @@
 			}
 		}
 
-		@media only screen and ( max-width: 600px ) {
+		@media only screen and (max-width: 600px) {
 			aspect-ratio: 1 / 1 !important;
 		}
 	}
@@ -103,8 +97,7 @@
 	}
 
 	& &__content-background.wp-block-group {
-
-		@media only screen and ( max-width: 781px ) {
+		@media only screen and (max-width: 781px) {
 			padding-top: 2.5rem;
 		}
 	}
@@ -116,14 +109,13 @@
 		.is-style-sans-p {
 			font-size: variables.$font-size-base;
 
-			@media only screen and ( min-width: 782px ) {
+			@media only screen and (min-width: 782px) {
 				font-size: variables.$font-size-xlarge;
 			}
 		}
 
 		.wp-block-wmf-reports-expandable {
-
-			@media only screen and ( min-width: 782px ) {
+			@media only screen and (min-width: 782px) {
 				border-left: 1px solid currentcolor;
 				padding-left: 2.875rem;
 				margin-left: 2rem;

--- a/src/patterns/welcome-page.scss
+++ b/src/patterns/welcome-page.scss
@@ -67,7 +67,7 @@
 	&__heading.alignwide {
 		margin-left: -2rem !important;
 
-		@media only screen and ( min-width: 782px ) {
+		@media only screen and (min-width: 782px) {
 			margin-left: auto !important;
 		}
 	}
@@ -112,7 +112,6 @@
 		margin-bottom: 0;
 
 		.wp-block-button.is-style-tertiary {
-
 			.wp-block-button__link.wp-element-button {
 				color: #00a0ff;
 				border-color: #00a0ff;
@@ -131,7 +130,7 @@
 .wmf-pattern-report-intro-columns.wp-block-columns {
 	margin-bottom: 0;
 
-	@media only screen and ( max-width: 781px ) {
+	@media only screen and (max-width: 781px) {
 		gap: 0;
 
 		.wp-block-column:nth-child(even) {
@@ -144,89 +143,19 @@
 		margin-bottom: 1rem;
 
 		button.dropdown-toggle {
-			cursor: pointer;
-			color: #000;
-			text-align: center;
-			border: 1px solid #aaa;
-			background: #fff;
-			border-radius: 0;
-			padding: 0.5rem;
 			width: 100%;
-
-			&:hover {
-				box-shadow: none;
-				color: #000;
-				opacity: 0.8;
-			}
-
-			&::after {
-				// stylelint-disable-next-line function-url-quotes
-				background: url('data:image/svg+xml,<svg width="13" height="8" viewBox="0 0 13 8" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.795181 1L6.26205 6L11.7289 1" stroke="black" stroke-width="2"/></svg>') center center no-repeat;
-				content: " ";
-				display: inline-block;
-				height: 1em;
-				margin-left: 0.5rem;
-				padding-left: 0.25rem;
-				width: 13px;
-				vertical-align: middle;
-			}
-		}
-
-		button.dropdown-toggle[aria-expanded="true"]::after {
-			transform: rotate(180deg);
 		}
 
 		ul {
-			position: absolute;
-			top: 2.2rem;
-			padding: 0;
+			height: 0;
 			margin: 0;
-			list-style-type: none;
+			position: absolute;
+			visibility: hidden;
 			width: 100%;
 			z-index: 2;
-			visibility: hidden;
-			height: 0;
 
-			li {
-				padding: 0;
-				margin: 0;
-				list-style-type: none;
-				width: 100%;
-
-				button {
-					cursor: pointer;
-					color: #666;
-					text-align: center;
-					border: 1px solid #eee;
-					background: #fff;
-					border-top: none;
-					border-radius: 0;
-					padding: 0.5rem;
-					width: 100%;
-
-					&:focus,
-					&:hover {
-						box-shadow: none;
-						background: #eee;
-						color: #666;
-						outline: none;
-					}
-				}
-
-				&:first-child button {
-					border-top: 1px solid #aaa;
-				}
-
-				&:nth-child(odd) button {
-					background: #f9f9f9;
-
-					&:focus,
-					&:hover {
-						background: #eee;
-						color: #666;
-						outline: none;
-					}
-				}
+			strong {
+				font-weight: inherit;
 			}
 		}
 
@@ -244,15 +173,14 @@
 	margin-bottom: 0;
 	padding: 0;
 
-	@media only screen and ( min-width: 782px ) {
+	@media only screen and (min-width: 782px) {
 		width: calc(100% + 3rem);
 		max-width: calc(100% + 3rem) !important;
 		margin-left: -1rem !important;
 	}
 
 	.wp-block-column:nth-child(even) {
-
-		@media only screen and ( max-width: 781px ) {
+		@media only screen and (max-width: 781px) {
 			margin-left: 0;
 		}
 	}
@@ -263,7 +191,7 @@
 	padding: 0 2rem;
 	width: calc(100% + 4rem);
 
-	@media only screen and ( min-width: 782px ) {
+	@media only screen and (min-width: 782px) {
 		border-radius: 30px;
 		width: calc(100% + 1rem);
 		margin-left: -1rem;
@@ -344,7 +272,6 @@
 		font-size: 15px;
 		margin-bottom: 1rem;
 	}
-
 }
 
 .wmf-pattern-report-intro-donate.wp-block-group {
@@ -372,7 +299,6 @@
 	}
 
 	.wp-block-column:nth-child(even) {
-
 		@media only screen and (max-width: 781px) {
 			margin-left: 0;
 		}

--- a/src/patterns/welcome-page.scss
+++ b/src/patterns/welcome-page.scss
@@ -1,8 +1,6 @@
 @use "../helpers/variables";
 
 .wmf-pattern-report-welcome {
-	padding: 0 !important;
-
 	h1,
 	h2,
 	h3,
@@ -19,57 +17,27 @@
 	p + p {
 		margin-top: 0;
 	}
-
-	.wp-block-group.alignfull,
-	.alignfull {
-		margin-left: 0;
-		margin-right: 0;
-		max-width: 100%;
-		padding-left: 0;
-		padding-right: 0;
-		width: 100%;
-
-		// stylelint-disable-next-line no-descending-specificity
-		.wp-block-group__inner-container {
-			padding: 0;
-		}
-	}
-
-	.wp-block-group.alignwide,
-	.alignwide {
-		margin-left: auto;
-		margin-right: auto;
-		max-width: variables.$width-breakpoint-wide !important;
-		width: 100%;
-
-		@media only screen and ( max-width: #{ variables.$width-breakpoint-wide + 64 } ) {
-			padding-left: 2rem;
-			padding-right: 2rem;
-		}
-	}
 }
 
 .wmf-pattern-report-into-hero {
-	padding: 0 !important;
+	display: grid;
+	padding-block: 0 !important;
 
-	// stylelint-disable-next-line no-descending-specificity
-	.wp-block-group__inner-container {
+	&__image.wp-block-image,
+	&__heading {
+		grid-column: 1 / span 1;
+		grid-row: 1 / span 1;
+	}
+
+	&__heading {
+		align-items: center;
+		display: flex;
+		margin: 0 !important;
+		width: 100%;
+	}
+
+	&__heading-pill {
 		position: relative;
-	}
-
-	&__heading-container {
-		margin-bottom: 0;
-		position: absolute;
-		top: 50%;
-		transform: translateY(-50%);
-	}
-
-	&__heading.alignwide {
-		margin-left: -2rem !important;
-
-		@media only screen and (min-width: 782px) {
-			margin-left: auto !important;
-		}
 	}
 
 	&__image.wp-block-image {
@@ -87,17 +55,15 @@
 	}
 
 	&__heading-label {
-		display: inline-block;
-		background: #000;
-		color: #fff;
-
-		font-weight: variables.$font-weight-base;
+		background: var(--wp--preset--color--main);
+		color: var(--wp--preset--color--base);
+		font-weight: var(--wp--custom--font-weight--normal);
 		text-transform: uppercase;
-		font-size: 15px;
+		font-size: var(--wp--preset--font-size--medium);
 		padding: 0.5rem 1rem 0.5rem 1rem;
 		margin-bottom: 1rem;
 		position: absolute;
-		top: -3rem;
+		top: -1rem;
 
 		// stylelint-disable-next-line no-descending-specificity
 		img {
@@ -244,7 +210,7 @@
 
 	&__link {
 		font-size: 18px;
-		margin-bottom: 0.5rem;
+		margin-top: 0.5rem !important;
 
 		a {
 			color: #000;
@@ -270,7 +236,7 @@
 
 	&__date {
 		font-size: 15px;
-		margin-bottom: 1rem;
+		margin-top: 0.5rem !important;
 	}
 }
 

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -8,7 +8,6 @@
 	}
 
 	&.admin-bar {
-
 		@media screen and (min-width: 600px) {
 			--scroll-margin-top: 46px; // Fixed admin bar.
 		}
@@ -25,39 +24,16 @@
 
 /* Theme overrides */
 .single-wmf-report {
-
 	.mw-980 {
 		max-width: none;
 		padding: 0;
 	}
 
-	.primary-nav {
-		margin-top: 3.875rem;
-	}
-
 	@media (min-width: 1024px) {
-		// We stack our nav on top of Shiro's, in that theme.
-		[data-dropdown-status="initialized"] .primary-nav {
-			min-height: 0;
-			height: 3rem;
-			margin-top: 3.75rem;
-		}
-
-		[data-dropdown-status="initialized"] .primary-nav__items {
-			max-width: variables.$width-breakpoint-wide;
-			margin: 0 auto;
-			padding: 0;
-		}
-
 		// Focus management to enable keyboard selection of page-level nav
 		// items even when they are occluded by the Report navigation.
 		.header-default {
 			position: relative;
-
-			.header-inner .primary-nav:focus-within {
-				background: #fff;
-				z-index: 3000; // overrides 2000 of .site-header
-			}
 		}
 	}
 
@@ -142,21 +118,6 @@
 		}
 	}
 
-	.wp-block-group.alignfull,
-	.alignfull {
-		margin-left: 0;
-		margin-right: 0;
-		max-width: 100%;
-		padding-left: 0;
-		padding-right: 0;
-		width: 100%;
-
-		// stylelint-disable-next-line no-descending-specificity
-		.wp-block-group__inner-container {
-			padding: 0;
-		}
-	}
-
 	.wp-block-group.alignwide,
 	.alignwide {
 		margin-left: auto;
@@ -212,7 +173,6 @@
 	}
 
 	#vg-tooltip-element table tr td {
-
 		&.key {
 			color: #444;
 		}
@@ -229,7 +189,6 @@
 }
 
 .wp-block-button.is-style-transparent {
-
 	.wp-block-button__link.has-base-100-background-color {
 		background: #fff !important;
 		cursor: pointer;


### PR DESCRIPTION
https://github.com/humanmade/Wikimedia/issues/1124

Miscellaneous annual report fixes for the UX Refresh, mostly to the annual reports home page.

Related PR:
https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/pull/133
https://github.com/wikimedia/shiro-wordpress-theme/pull/211

Testing:
https://wikimediafoundation-org-develop.go-vip.co/about/annualreport/
https://wikimediafoundation-org-develop.go-vip.co/annualreports/2022-2023-annual-report/