### PR TITLE
Hotfix: Fix z-index overlapping main navigation

### DIFF
--- a/src/patterns/carousel.scss
+++ b/src/patterns/carousel.scss
@@ -4,6 +4,7 @@
 .wp-block-wmf-reports-stories.carousel {
 	overflow: hidden;
 	position: relative;
+	z-index: 0;
 
 	.carousel-wrapper {
 		position: relative;


### PR DESCRIPTION
Tiny fix for the annual reports maps and stories carousel buttons, so they don't overlap the main menu.