### PR TITLE
1128: Use SVG renderer for Vegalite blocks everywhere

### DIFF
--- a/inc/blocks/datavis.php
+++ b/inc/blocks/datavis.php
@@ -27,9 +27,7 @@ function inject_embed_config( string $block_content, array $block ) : string {
 	if ( $block['blockName'] !== 'vegalite-plugin/visualization' ) {
 		return $block_content;
 	}
-	if ( ! is_singular( Report\POST_TYPE ) ) {
-		return $block_content;
-	}
+
 	return str_replace(
 		'class="visualization-block"',
 		sprintf(


### PR DESCRIPTION
https://github.com/humanmade/Wikimedia/issues/1128

We're using the Vegalite visualization block in more places now, and we need the SVG renderer so that it is clickable on mobile. This PR takes out the check that the block is being used in a single report post.