### PR TITLE
1112: Rotate map arrows appropriately on RTL

### DIFF
--- a/src/patterns/carousel.scss
+++ b/src/patterns/carousel.scss
@@ -56,12 +56,13 @@
 			transform: scaleX(-1);
 		}
 
-
-		:dir(rtl) & {
+		:dir(rtl) &,
+		.direction-rtl & {
 			transform: scaleX(-1);
 		}
 
-		:dir(rtl) &--back {
+		:dir(rtl) &--back,
+		.direction-rtl &--back {
 			transform: scaleX(1);
 		}
 

--- a/src/patterns/carousel.scss
+++ b/src/patterns/carousel.scss
@@ -56,6 +56,15 @@
 			transform: scaleX(-1);
 		}
 
+
+		:dir(rtl) & {
+			transform: scaleX(-1);
+		}
+
+		:dir(rtl) &--back {
+			transform: scaleX(1);
+		}
+
 		&:active {
 			opacity: 0.8;
 		}


### PR DESCRIPTION
@joeleenk This currently has no effect because e.g. Arabic has no `dir="rtl"` attribute, so there is no way to target or trigger the :dir selector. I see the `direction: rtl` rule in the CSS but it doesn't change when this rule goes into effect.