### PR TITLE
1123: Prevent encoded lottielabInfoHTML from breaking editor on load

### DIFF
--- a/inc/blocks/animation.php
+++ b/inc/blocks/animation.php
@@ -6,11 +6,18 @@ declare( strict_types=1 );
 
 namespace WMF\Reports\Blocks\Animation;
 
+use WMF\Reports\Report;
+use WP_REST_Response;
+
 /**
  * Attach hooks.
  */
 function bootstrap() : void {
 	add_filter( 'render_block', __NAMESPACE__ . '\\strip_problematic_encoded_html', 10, 2 );
+	// TODO: Refactor to use a more central hook so we do not need to enumerate each type.
+	add_filter( 'rest_prepare_post', __NAMESPACE__ . '\\strip_problematic_encoded_html_from_rest_content' );
+	add_filter( 'rest_prepare_page', __NAMESPACE__ . '\\strip_problematic_encoded_html_from_rest_content' );
+	add_filter( 'rest_prepare_' . Report\POST_TYPE, __NAMESPACE__ . '\\strip_problematic_encoded_html_from_rest_content' );
 }
 
 /**
@@ -27,4 +34,23 @@ function strip_problematic_encoded_html( string $block_content ) : string {
 		return $block_content;
 	}
 	return preg_replace( '/&quot;lottielabInfoHTML&quot;:&quot;.*?&quot;/', '', $block_content );
+}
+
+/**
+ * When dispatching a REST request, if it contains a content.raw property,
+ * run it through the encoded HTML removal filter above. This allows the
+ * field to be transparently removed from the post content on load.
+ *
+ * @param WP_REST_Response $response Outgoing REST response.
+ * @return WP_REST_Response Filtered response.
+ */
+function strip_problematic_encoded_html_from_rest_content( $response ) {
+	$data = $response->get_data();
+	if ( empty( $data['content']['raw'] ) || ! is_string( $data['content']['raw'] ) ) {
+		return $response;
+	}
+
+	$data['content']['raw'] = strip_problematic_encoded_html( $data['content']['raw'] );
+	$response->set_data( $data );
+	return $response;
 }

--- a/inc/blocks/animation.php
+++ b/inc/blocks/animation.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Block-specific PHP logic for the Overlay block.
+ */
+declare( strict_types=1 );
+
+namespace WMF\Reports\Blocks\Animation;
+
+/**
+ * Attach hooks.
+ */
+function bootstrap() : void {
+	add_filter( 'render_block', __NAMESPACE__ . '\\strip_problematic_encoded_html', 10, 2 );
+}
+
+/**
+ * If there is a lottielabInfoHTML attribute in the encoded HTML, remove it.
+ *
+ * The HTML inside that attribute is improperly escaped when bootstrapping
+ * the block editor, and causes a JS parse error.
+ *
+ * @param string $block_content The block content.
+ * @return string Filtered block content.
+ */
+function strip_problematic_encoded_html( string $block_content ) : string {
+	if ( strpos( $block_content, 'lottielabInfoHTML' ) === false ) {
+		return $block_content;
+	}
+	return preg_replace( '/&quot;lottielabInfoHTML&quot;:&quot;.*?&quot;/', '', $block_content );
+}

--- a/plugin.php
+++ b/plugin.php
@@ -18,6 +18,7 @@ const PLUGIN_PATH = __DIR__;
 require_once __DIR__ . '/inc/assets.php';
 require_once __DIR__ . '/inc/asset-loader/namespace.php';
 require_once __DIR__ . '/inc/asset-loader/utilities.php';
+require_once __DIR__ . '/inc/blocks/animation.php';
 require_once __DIR__ . '/inc/blocks/core-group.php';
 require_once __DIR__ . '/inc/blocks/datavis.php';
 require_once __DIR__ . '/inc/blocks/expandable.php';
@@ -50,6 +51,7 @@ require_once __DIR__ . '/inc/theme-integration.php';
 require_once __DIR__ . '/inc/utilities.php';
 
 Assets\bootstrap();
+Blocks\Animation\bootstrap();
 Blocks\Core_Group\bootstrap();
 Blocks\Datavis\bootstrap();
 Blocks\Expandable\bootstrap();


### PR DESCRIPTION
This PR begins to address WIKI-1123 by stripping out the encoded lottielabInfoHTML property from within animation block JSON, both on-render (which allows the editor to load properly) and in REST responses (which ensures that if you load a page with the offending markup, it will be stripped before it gets to the editor and therefore will be removed from the DB if the page is re-saved.)