### PR TITLE
1188 fix custom property fallback for jumplist

### DIFF
--- a/src/blocks/table-of-contents/_jumplist.scss
+++ b/src/blocks/table-of-contents/_jumplist.scss
@@ -156,7 +156,7 @@ $indicator-cutoff-width: 1200px;
 		left: 0;
 		margin: 0 !important;
 		position: fixed;
-		top: calc(76px + var(--wp-admin--admin-bar--height, 0));
+		top: calc(76px + var(--wp-admin--admin-bar--height, 0px));
 		width: 100%;
 		z-index: 20;
 


### PR DESCRIPTION
Based on the CSS spec for custom properties, this should not make a difference. And yet it does.

This PR tweaks the `calc` for the positioning of the jumplist to use an explicit pixel value for the custom property fallback, causing it to render correctly. Otherwise, it acts as if the rule is not present if the custom property does not exist (i.e. when a user is not logged in)