### PR TITLE
Update Jumplist styles for active item

### DIFF
--- a/src/blocks/table-of-contents/_jumplist.scss
+++ b/src/blocks/table-of-contents/_jumplist.scss
@@ -93,7 +93,8 @@ $indicator-cutoff-width: 1200px;
 				&,
 				&:hover,
 				&:active {
-					color: #fff;
+					// We need to use !important here in order to override other !important styles.
+					color: #fff !important;
 				}
 
 				&::before {


### PR DESCRIPTION
This PR fixes an issue with the jumplist TOC component on mobile, where the colour is not correctly applied due to other styles using `!important` which affect this.

Ideally in future we should revisit these styles, however for now this is a straightforward time-sensitive fix.