### PR TITLE
Lottie Lite compatibility

### DIFF
--- a/inc/editor/patterns/hero.php
+++ b/inc/editor/patterns/hero.php
@@ -11,7 +11,7 @@ const PATTERN = <<<CONTENT
 <!-- wp:group {"tagName":"section","metadata":{"name":"Hero"},"align":"full","className":"wmf-pattern-reports-hero is-style-default","backgroundColor":"wmf-report-blue"} -->
 <section class="wp-block-group alignfull wmf-pattern-reports-hero is-style-default has-wmf-report-blue-background-color has-background"><!-- wp:group {"align":"full","className":"wmf-pattern-reports-hero__head"} -->
 <div class="wp-block-group alignfull wmf-pattern-reports-hero__head"><!-- wp:image {"id":74502,"sizeSlug":"large","linkDestination":"none","lock":{"move":false,"remove":false},"align":"full","className":"wmf-pattern-reports-hero__image"} -->
-<figure class="wp-block-image alignfull size-large wmf-pattern-reports-hero__image"><img src="/wp-content/uploads/2024/04/PrenticeHandMural.jpg?w=1024" alt="" class="wp-image-74502"/></figure>
+<figure class="wp-block-image alignfull size-large wmf-pattern-reports-hero__image wmf-animation"><img src="/wp-content/uploads/2024/04/PrenticeHandMural.jpg?w=1024" alt="" class="wp-image-74502"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:group {"align":"full","className":"wmf-pattern-reports-hero__heading-container"} -->

--- a/inc/editor/patterns/report.php
+++ b/inc/editor/patterns/report.php
@@ -12,7 +12,7 @@ const PATTERN = <<<CONTENT
 <div class="wp-block-group alignfull report-background has-base-90-background-color has-background"><!-- wp:group {"tagName":"section","metadata":{"name":"Hero"},"align":"full","className":"wmf-pattern-reports-hero is-style-default","backgroundColor":"wmf-report-blue"} -->
 <section class="wp-block-group alignfull wmf-pattern-reports-hero is-style-default has-wmf-report-blue-background-color has-background"><!-- wp:group {"align":"full","className":"wmf-pattern-reports-hero__head"} -->
 <div class="wp-block-group alignfull wmf-pattern-reports-hero__head"><!-- wp:image {"id":74502,"sizeSlug":"large","linkDestination":"none","lock":{"move":false,"remove":false},"align":"full","className":"wmf-pattern-reports-hero__image"} -->
-<figure class="wp-block-image alignfull size-large wmf-pattern-reports-hero__image"><img src="/wp-content/uploads/2024/04/PrenticeHandMural.jpg?w=1024" alt="" class="wp-image-74502"/></figure>
+<figure class="wp-block-image alignfull size-large wmf-pattern-reports-hero__image wmf-animation"><img src="/wp-content/uploads/2024/04/PrenticeHandMural.jpg?w=1024" alt="" class="wp-image-74502"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:group {"align":"full","className":"wmf-pattern-reports-hero__heading-container"} -->

--- a/src/patterns/hero.scss
+++ b/src/patterns/hero.scss
@@ -105,6 +105,16 @@
 			svg {
 				width: auto !important;
 			}
+
+
+			/* Canvas styles for use with Lottie Lite plugin */
+			canvas {
+				height: 100%;
+				width: auto !important;
+				max-width: unset;
+				left: 0 !important;
+				transform: translatey(-50%) !important;
+			}
 		}
 
 		@media only screen and (max-width: 600px) {


### PR DESCRIPTION
Some tweaks to add compatibility for https://github.com/humanmade/lottie-lite, which should be a replacement for the Lottie animations block going forward.

Lottie Lite uses an html canvas and an image, so these classes and style tweaks keep things consistent. 