### PR TITLE
1226 WP 7.0 Compatibility

### DIFF
--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -120,14 +120,23 @@ const MapPreview = ( {
 			map = null;
 		}
 
+		// Clear the container to avoid "map container should be empty" warnings
+		// when re-initialising.
+		containerRef.current.innerHTML = '';
+
 		/**
-		 * Create the container in the parent frame so that Mapbox initialises
-		 * properly, then move the container into the iframed editor below.
+		 * The block canvas is an iframe, but this script (and its bundled
+		 * mapbox-gl) runs in the parent window. Create the container with the
+		 * parent document so it passes Mapbox's `instanceof HTMLElement` check,
+		 * then append it into the iframe *before* constructing the map: the node
+		 * keeps its parent realm, but its ownerDocument becomes the iframe, so
+		 * Mapbox binds its interaction handlers there. Initialising while the
+		 * container is still in the parent frame binds panning to the wrong
+		 * realm and makes the map jump during drags.
 		 */
 		const mapContainer = document.createElement( 'div' );
-		mapContainer.style.cssText =
-			'position:fixed;top:-9999px;left:-9999px;width:800px;height:400px;';
-		document.body.appendChild( mapContainer );
+		mapContainer.style.cssText = 'width:100%;height:100%;';
+		containerRef.current.appendChild( mapContainer );
 
 		mapboxgl.accessToken = wmf.apiKey;
 		map = new mapboxgl.Map( {
@@ -142,14 +151,6 @@ const MapPreview = ( {
 		} );
 
 		map.addControl( fullScreenControl );
-
-		/**
-		 * Move the container (including Mapbox's WebGL canvas) into the iframe.
-		 * This should replace any previous versions in case a re-render requires this to be recreated.
-		 */
-		mapContainer.style.cssText = 'width:100%;height:100%;';
-		containerRef.current.replaceChildren( mapContainer );
-		map.resize();
 
 		const slideMarkers = JSON.parse( serializedFeatures );
 

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -231,7 +231,7 @@ const MapPreview = ( {
 		// We do not want a change to map attributes to trigger a re-render, that
 		// is handled separately below.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ map, mapStyle, serializedFeatures, updateMarkers ] );
+	}, [ mapStyle, serializedFeatures, updateMarkers ] );
 
 	useEffect( () => {
 		if ( map ) {

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -346,9 +346,16 @@ const Edit = ( {
 			return;
 		}
 
+		// Mapbox's container was moved into the editor iframe, so the marker
+		// elements it appends live in that document. Query them against the
+		// map's own document so reconciliation finds existing markers instead
+		// of recreating duplicates every render. The elements themselves are
+		// still created in the parent frame (see below) to satisfy Mapbox's
+		// `instanceof HTMLElement` check.
+		const mapDocument = map.getContainer().ownerDocument;
 		const features = map.querySourceFeatures( 'markers' );
-		const mapMarkers = document.getElementsByClassName( 'marker' );
-		const clusterMarkers = document.getElementsByClassName( 'cluster' );
+		const mapMarkers = mapDocument.getElementsByClassName( 'marker' );
+		const clusterMarkers = mapDocument.getElementsByClassName( 'cluster' );
 		const newMarkers = [];
 		const newClusters = [];
 

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -112,6 +112,7 @@ const MapPreview = ( {
 		const fullScreenControl = new mapboxgl.NavigationControl();
 
 		if ( map ) {
+			map.removeControl( fullScreenControl );
 			map.remove();
 			map = null;
 		}
@@ -230,7 +231,7 @@ const MapPreview = ( {
 		// We do not want a change to map attributes to trigger a re-render, that
 		// is handled separately below.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ containerRef, map, mapStyle, serializedFeatures, updateMarkers ] );
+	}, [ map, mapStyle, serializedFeatures, updateMarkers ] );
 
 	useEffect( () => {
 		if ( map ) {

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -7,8 +7,7 @@ import {
 	withColors,
 } from '@wordpress/block-editor';
 import {
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalNumberControl as NumberControl,
+	NumberControl,
 	PanelBody,
 	TextControl,
 	SelectControl,
@@ -105,21 +104,31 @@ const MapPreview = ( {
 			return;
 		}
 
+		if ( ! containerRef.current ) {
+			return;
+		}
+
 		const fullScreenControl = new mapboxgl.NavigationControl();
 
 		if ( map ) {
-			map.removeControl( fullScreenControl );
 			map.remove();
+			map = null;
 		}
 
-		if ( containerRef.current ) {
-			// Clear out DIV to avoid "The map container element should be empty"
-			// warnings when re-rendering.
-			containerRef.current.innerHTML = '';
-		}
+		// WordPress 7.0's iframed editor runs block scripts in the parent frame,
+		// but containerRef.current lives in the iframe's document. Mapbox validates
+		// the container with `instanceof HTMLElement` against the parent frame's
+		// constructor, which fails for cross-frame elements. As a workaround, create
+		// the container in the parent frame, initialize Mapbox into it (passing the
+		// instanceof check), then move it into the iframe block element.
+		const mapContainer = document.createElement( 'div' );
+		mapContainer.style.cssText =
+			'position:fixed;top:-9999px;left:-9999px;width:800px;height:400px;';
+		document.body.appendChild( mapContainer );
+
 		mapboxgl.accessToken = wmf.apiKey;
 		map = new mapboxgl.Map( {
-			container: 'map',
+			container: mapContainer,
 			center: [ longitude || 0, latitude || 0 ],
 			minZoom: 0,
 			projection,
@@ -130,6 +139,13 @@ const MapPreview = ( {
 		} );
 
 		map.addControl( fullScreenControl );
+
+		// Move the container (including Mapbox's WebGL canvas) into the iframe block
+		// element. Node adoption preserves the WebGL context in modern browsers.
+		// Clear any leftover container from a previous render first.
+		mapContainer.style.cssText = 'width:100%;height:100%;';
+		containerRef.current.replaceChildren( mapContainer );
+		map.resize();
 
 		const slideMarkers = JSON.parse( serializedFeatures );
 
@@ -210,7 +226,7 @@ const MapPreview = ( {
 		// We do not want a change to map attributes to trigger a re-render, that
 		// is handled separately below.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ mapStyle, serializedFeatures, updateMarkers ] );
+	}, [ containerRef, map, mapStyle, serializedFeatures, updateMarkers ] );
 
 	useEffect( () => {
 		if ( map ) {
@@ -224,7 +240,7 @@ const MapPreview = ( {
 	return (
 		<div
 			id="map"
-			style={ { minHeight: '250px' } }
+			style={ { height: '250px' } }
 			ref={ containerRef }
 		></div>
 	);

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -7,7 +7,10 @@ import {
 	withColors,
 } from '@wordpress/block-editor';
 import {
-	NumberControl,
+	// NumberControl is not stabilised as of WP 7.0; the unprefixed export is
+	// undefined and crashes the block when the inspector mounts.
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalNumberControl as NumberControl,
 	PanelBody,
 	TextControl,
 	SelectControl,

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -118,12 +118,8 @@ const MapPreview = ( {
 		}
 
 		/**
-		 * WP 7.0's iframed editor runs block scripts in the parent frame, but containerRef.current lives
-		 * in the editor iframe. Mapbox validates the container with `instanceof HTMLElement` against the
-		 * parent frame's constructor, which fails here.
-		 *
-		 * As a workaround, create the container in the parent frame, initialize Mapbox into it (passing the instanceof check),
-		 * then move it into the block render inside the iframe.
+		 * Create the container in the parent frame so that Mapbox initialises
+		 * properly, then move the container into the iframed editor below.
 		 */
 		const mapContainer = document.createElement( 'div' );
 		mapContainer.style.cssText =
@@ -243,11 +239,7 @@ const MapPreview = ( {
 	}, [ projection, latitude, longitude, zoom ] );
 
 	return (
-		<div
-			id="map"
-			style={ { height: '250px' } }
-			ref={ containerRef }
-		></div>
+		<div id="map" style={ { height: '250px' } } ref={ containerRef }></div>
 	);
 };
 
@@ -346,12 +338,8 @@ const Edit = ( {
 			return;
 		}
 
-		// Mapbox's container was moved into the editor iframe, so the marker
-		// elements it appends live in that document. Query them against the
-		// map's own document so reconciliation finds existing markers instead
-		// of recreating duplicates every render. The elements themselves are
-		// still created in the parent frame (see below) to satisfy Mapbox's
-		// `instanceof HTMLElement` check.
+		// Look up markers in the map's own document (the iframe under WP 7.0),
+		// where Mapbox appends them, so we reconcile instead of duplicating.
 		const mapDocument = map.getContainer().ownerDocument;
 		const features = map.querySourceFeatures( 'markers' );
 		const mapMarkers = mapDocument.getElementsByClassName( 'marker' );

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -152,6 +152,45 @@ const MapPreview = ( {
 
 		map.addControl( fullScreenControl );
 
+		// Mapbox's built-in drag-pan is driven by mouse events. The WP 7.0
+		// editor iframe re-dispatches those to the parent frame (where mapbox-gl
+		// runs) offset by the iframe's position, so the map jumps on the first
+		// drag movement. Pointer events are not re-dispatched, so drive panning
+		// from them instead, keeping the whole gesture in the iframe realm.
+		map.dragPan.disable();
+		const mapDocument = mapContainer.ownerDocument;
+		let panLastX = 0;
+		let panLastY = 0;
+		const onPanMove = ( event ) => {
+			map.panBy( [ panLastX - event.clientX, panLastY - event.clientY ], {
+				animate: false,
+			} );
+			panLastX = event.clientX;
+			panLastY = event.clientY;
+		};
+		const onPanEnd = () => {
+			mapDocument.removeEventListener( 'pointermove', onPanMove );
+			mapDocument.removeEventListener( 'pointerup', onPanEnd );
+			mapDocument.removeEventListener( 'pointercancel', onPanEnd );
+		};
+		mapContainer.addEventListener( 'pointerdown', ( event ) => {
+			// Only pan from the map background; markers, clusters and controls
+			// keep their own gestures.
+			if (
+				event.button !== 0 ||
+				event.target.closest(
+					'.marker, .cluster, .mapboxgl-marker, .mapboxgl-ctrl'
+				)
+			) {
+				return;
+			}
+			panLastX = event.clientX;
+			panLastY = event.clientY;
+			mapDocument.addEventListener( 'pointermove', onPanMove );
+			mapDocument.addEventListener( 'pointerup', onPanEnd );
+			mapDocument.addEventListener( 'pointercancel', onPanEnd );
+		} );
+
 		const slideMarkers = JSON.parse( serializedFeatures );
 
 		map.on( 'load', () => {

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -104,6 +104,7 @@ const MapPreview = ( {
 			return;
 		}
 
+		// Exit if the container ref is not set, as we need the container.
 		if ( ! containerRef.current ) {
 			return;
 		}
@@ -115,12 +116,14 @@ const MapPreview = ( {
 			map = null;
 		}
 
-		// WordPress 7.0's iframed editor runs block scripts in the parent frame,
-		// but containerRef.current lives in the iframe's document. Mapbox validates
-		// the container with `instanceof HTMLElement` against the parent frame's
-		// constructor, which fails for cross-frame elements. As a workaround, create
-		// the container in the parent frame, initialize Mapbox into it (passing the
-		// instanceof check), then move it into the iframe block element.
+		/**
+		 * WP 7.0's iframed editor runs block scripts in the parent frame, but containerRef.current lives
+		 * in the editor iframe. Mapbox validates the container with `instanceof HTMLElement` against the
+		 * parent frame's constructor, which fails here.
+		 *
+		 * As a workaround, create the container in the parent frame, initialize Mapbox into it (passing the instanceof check),
+		 * then move it into the block render inside the iframe.
+		 */
 		const mapContainer = document.createElement( 'div' );
 		mapContainer.style.cssText =
 			'position:fixed;top:-9999px;left:-9999px;width:800px;height:400px;';
@@ -140,9 +143,10 @@ const MapPreview = ( {
 
 		map.addControl( fullScreenControl );
 
-		// Move the container (including Mapbox's WebGL canvas) into the iframe block
-		// element. Node adoption preserves the WebGL context in modern browsers.
-		// Clear any leftover container from a previous render first.
+		/**
+		 * Move the container (including Mapbox's WebGL canvas) into the iframe.
+		 * This should replace any previous versions in case a re-render requires this to be recreated.
+		 */
 		mapContainer.style.cssText = 'width:100%;height:100%;';
 		containerRef.current.replaceChildren( mapContainer );
 		map.resize();
@@ -235,7 +239,7 @@ const MapPreview = ( {
 			map.setCenter( [ longitude || 0, latitude || 0 ] );
 			map.setZoom( zoom || 1 );
 		}
-	}, [ projection, latitude, longitude, zoom ] );
+	}, [ projection, latitude, longitude, zoom ] );https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/actions/runs/25802242964/job/75795192655?pr=145
 
 	return (
 		<div

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -239,7 +239,7 @@ const MapPreview = ( {
 			map.setCenter( [ longitude || 0, latitude || 0 ] );
 			map.setZoom( zoom || 1 );
 		}
-	}, [ projection, latitude, longitude, zoom ] );https://github.com/wikimedia/wikimedia-wordpress-annual-report-plugin/actions/runs/25802242964/job/75795192655?pr=145
+	}, [ projection, latitude, longitude, zoom ] );
 
 	return (
 		<div


### PR DESCRIPTION
1226 WP 7.0 Compatibility

This resolves an error with the Map block in WordPress 7.0. Because this is now within an iframe, the JS to initialise the map cannot find the map container. As a workaround, we initialise the element and then move it to where it needs to be.